### PR TITLE
HOFF-422: Replace hof-rds-api Image (WAIT FOR REGRESSION TESTING)

### DIFF
--- a/kube/hof-rds-api/deployment.yml
+++ b/kube/hof-rds-api/deployment.yml
@@ -33,7 +33,7 @@ spec:
       containers:
         - name: data-service
           # release v2.0.1
-          image: quay.io/ukhomeofficedigital/hof-rds-api:d3b46ecf5915310538c63bfb20e45b373d3d4091
+          image: quay.io/ukhomeofficedigital/hof-rds-api:f72489e134c4e80740cb919602409b61f82ae598
           imagePullPolicy: Always
           envFrom:
             - configMapRef:


### PR DESCRIPTION
What?

Fix Vulnerabilities in hof-rds-api Image. These vulnerabilities can be in base Image and Yarn Packages. And Update Image from Branch (dev) to Prod. see ticket
#[HOFF-422](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-422)

**Why?**

The CVE List is a set of records that describe specific vulnerabilities or exposures. It is maintained by a large community of trusted entities and individuals.
A vulnerability is a flaw in a software, firmware, hardware, or service component that can be exploited to cause a negative impact to the confidentiality, integrity, or availability of an impacted component or components.
An exposure is a code or configuration error that can be exploited to gain indirect and often hard-to-discover access to application data such as customer information.

**How?**

Used Trivy to Scan Images and as a result Vulnerabilities found in Yarn packages.
Used yarn upgrade to upgrade outdated and vulnerable packages to latest versions
Built a new hof-rds-api image with upgraded yarn packages and no vulnerabilities found with Trivy Scanner
Please refer to below Trivy report,
https://confluence.bics-collaboration.homeoffice.gov.uk/display/FBISC/hoff+-+Trivy+-+hof-rds-api:f72489e134c4e80740cb919602409b61f82ae598

**Testing?**

Ingress url for Branch : https://ima-hoff-422.internal.branch.sas-notprod.homeoffice.gov.uk/your-details
Pods are healthy in Branch Env:
kubectl --context=acp-notprod_SAS --namespace=sas-ima-branch get pods | grep "hoff-422"
We will need to perform regression testing, and Merge these changes to Master Branch to test the services in QAT 