### PR TITLE
IMB-76-back-button-missing-bug-fix

### DIFF
--- a/apps/verify/index.js
+++ b/apps/verify/index.js
@@ -11,7 +11,9 @@ module.exports = {
       fields: ['uan', 'date-of-birth'],
       next: '/enter-email'
     },
-    '/details-not-found': {},
+    '/details-not-found': {
+      backLink: 'your-details'
+    },
     '/enter-email': {
       fields: ['user-email'],
       behaviours: [SendVerificationEmail],


### PR DESCRIPTION
## What
-Back button missing from the page as per FIGMA  [IMB-76](https://collaboration.homeoffice.gov.uk/jira/browse/IMB-76)

## Why
- Back button missing in the details not found page, in-line with Figma

## How
- Backlink: 'your-details' added in details not found  in index.js

## Testing
- Tests passing locally
