### PR TITLE
IMB-73 Save and exit button bug fix

### DIFF
--- a/apps/ima/index.js
+++ b/apps/ima/index.js
@@ -604,6 +604,7 @@ module.exports = {
       behaviours: [SaveFormSession, SaveImage('image'), RemoveImage, LimitDocument],
       fields: ['image'],
       continueOnEdit: true,
+      locals: { showSaveAndExit: true },
       next: '/final-summary'
     },
     '/final-summary': {

--- a/apps/ima/views/evidence-upload.html
+++ b/apps/ima/views/evidence-upload.html
@@ -36,8 +36,5 @@
 
     <br><br>
     {{#input-submit}}continue{{/input-submit}}
-    <button class="govuk-button govuk-button--secondary" name="save-and-exit" value="save-and-exit">
-      {{#t}}buttons.save-and-exit{{/t}}
-    </button>
   {{/page-content}}
 {{/partials-page}}

--- a/apps/ima/views/partials/form.html
+++ b/apps/ima/views/partials/form.html
@@ -7,7 +7,7 @@
 
   {{#showSaveAndExit}}
     {{^loopedPage}}
-      <button class="govuk-button govuk-button--secondary" name="save-and-exit" value="save-and-exit">
+      <button class="govuk-button govuk-button--secondary save-and-exit-button" name="save-and-exit" value="save-and-exit">
         {{#t}}buttons.save-and-exit{{/t}}
       </button>
     {{/loopedPage}}

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -295,3 +295,7 @@ p:has(span.medical-paragraph) {
 div > .section-header[data-content="Case details"]{
  display: none;
 }
+
+.save-and-exit-button {
+  margin-left: 15px;
+}


### PR DESCRIPTION
## What
-Save and Exit button missing from the page as per FIGMA  [IMB-73](https://collaboration.homeoffice.gov.uk/jira/browse/IMB-73)

## Why
- Save and Exit button missing in the summary page, in-line with Sigma

## How
- Save and Exit button already exist in master but the spacing between Continue and Save and Exit button is not the same as in GDS. So changed the space with save-and exit-button  SCSS in form.html (partials) and using margin-left with 15 px. It is global change and it will be reflected in all the pages.
- In evidence upload page Save and Exit button spacing is changed in line with other pages with div removed and in index.js showSaveAndExit: true is added in evidence-upload

## Testing
- Tests passing locally

