### PR TITLE
IMB-97 textarea input removed bug fix

### DIFF
--- a/apps/ima/behaviours/save-image.js
+++ b/apps/ima/behaviours/save-image.js
@@ -41,15 +41,13 @@ module.exports = name => superclass => class extends superclass {
         const invalidSize = uploadSizeTooBig || uploadSizeBeyondServerLimits;
 
         if (invalidSize || invalidMimetype) {
-          return new this.ValidationError(key, {
-            key,
+          return new this.ValidationError('image', {
             type: invalidSize ? 'maxFileSize' : 'fileType',
             redirect: undefined
           });
         }
       } else {
-        return new this.ValidationError(key, {
-          key,
+        return new this.ValidationError('image', {
           type: 'required',
           redirect: undefined
         });
@@ -65,6 +63,11 @@ module.exports = name => superclass => class extends superclass {
       const noMoreImagesToUpload = req.form.values['evidence-upload-more'] === 'no';
       const noImagesInSession = !_.get(req.sessionModel.get('images'), 'length');
       const steps = req.sessionModel.get('steps');
+      const lateSubmissionDetails = req.form.values['late-submission'];
+
+      if(lateSubmissionDetails) {
+        req.sessionModel.set('late-submission', lateSubmissionDetails);
+      }
 
       if (noImagesToUpload || (noMoreImagesToUpload && noImagesInSession)) {
         req.sessionModel.set('evidence-upload', 'no');


### PR DESCRIPTION
## What
-'Why are you submitting this form late?' textarea input is removed if upload button is clicked before continue/save and exit button [IMB-97](https://collaboration.homeoffice.gov.uk/jira/browse/IMB-97)

## Why
- Textarea input is removed if upload button is clicked before continue/save and exit button and even with text it shows error message

## How
- New constant latesubmissiondetails is declared in save-image.js. If it exist then set in the session model in setValues method.
- In ValidationField method ValidationError is modified with image instead of key.

## Testing
- Tests passing locally


