### PR TITLE
Fix: Stub Cases method in server spec

### DIFF
--- a/test/_unit/server.spec.js
+++ b/test/_unit/server.spec.js
@@ -7,6 +7,7 @@ describe('Server.js app file', () => {
   let appsImaStub;
   let appsUanStub;
   let behavioursClearSessionStub;
+  let casesStub;
   let req;
   let res;
   let next;
@@ -32,6 +33,7 @@ describe('Server.js app file', () => {
     appsUanStub = sinon.stub();
     appsImaStub = sinon.stub();
     behavioursClearSessionStub = sinon.stub();
+    casesStub = sinon.stub();
     req.get.withArgs('host').returns('localhost');
 
     useStub.onCall(0).yields(req, res, next);
@@ -44,7 +46,8 @@ describe('Server.js app file', () => {
       './apps/uan': appsUanStub,
       './apps/verify': appsVerifyStub,
       'hof/components/clear-session': behavioursClearSessionStub,
-      './config': { env: 'test' }
+      './config': { env: 'test' },
+      './apps/ima/models/cases': casesStub
     });
   });
 
@@ -86,7 +89,8 @@ describe('Server.js app file', () => {
 
       proxyquire('../server', {
         hof: hof,
-        './config': { env: 'development' }
+        './config': { env: 'development' },
+        './apps/ima/models/cases': casesStub
       });
 
       useStub.callCount.should.equal(3);
@@ -98,7 +102,8 @@ describe('Server.js app file', () => {
 
       proxyquire('../server', {
         hof: hof,
-        './config': { env: 'production' }
+        './config': { env: 'production' },
+        './apps/ima/models/cases': casesStub
       });
 
       use.should.have.been.calledTwice;


### PR DESCRIPTION
## What?

Stub the 'Cases' method import in server.js test file.

## Why?

Importing this file and using its class appears to be trying to connect the test environment to AWS by updating the configuration and creating an S3 object.

There is no variables available in test to do this so it throws and error. Confusingly the AWS function seems to run async so its error is thrown into other tests in the runner. Hopefully this stubbing will stop the attempted connection and allow all tests to run without errors being thrown as a side-effect.

## Testing?

Stubs fine locally when AWS values are removed from code.
