### PR TITLE
IMB-45: Amend the 'Information you have given us' page for the ban-only flow

### DIFF
--- a/apps/ima/fields/index.js
+++ b/apps/ima/fields/index.js
@@ -779,7 +779,7 @@ module.exports = {
     mixin: 'checkbox-group',
     labelClassName: 'visuallyhidden',
     legend: {
-      className: 'bold'
+      className: 'visuallyhidden'
     },
     validate: 'required',
     options: [{

--- a/apps/ima/index.js
+++ b/apps/ima/index.js
@@ -176,7 +176,7 @@ module.exports = {
         {
           target: '/temporary-permission',
           condition: req => {
-            if (req.sessionModel.get('has-address') === 'no' && req.sessionModel.get('duty-to-remove-alert') === 'yes') {
+            if (req.sessionModel.get('has-address') === 'no' && req.sessionModel.get('duty-to-remove-alert') === 'no') {
               return true;
             }
             return false;
@@ -185,7 +185,7 @@ module.exports = {
         {
           target: '/exception',
           condition: req => {
-            if (req.sessionModel.get('has-address') === 'no' && req.sessionModel.get('duty-to-remove-alert') === 'no') {
+            if (req.sessionModel.get('has-address') === 'no' && req.sessionModel.get('duty-to-remove-alert') === 'yes') {
               return true;
             }
             return false;
@@ -206,10 +206,29 @@ module.exports = {
     },
     '/medical-records': {
       behaviours: SaveFormSession,
+      forks: [
+        {
+          target: '/temporary-permission',
+          condition: req => {
+            if (req.sessionModel.get('duty-to-remove-alert') === 'no') {
+              return true;
+            }
+            return false;
+          }
+        },
+        {
+          target: '/exception',
+          condition: req => {
+            if (req.sessionModel.get('duty-to-remove-alert') === 'yes') {
+              return true;
+            }
+            return false;
+          }
+        }
+      ],
       fields: ['has-permission-access', 'permission-response'],
       locals: { showSaveAndExit: true },
       continueOnEdit: true,
-      next: '/temporary-permission', // TODO - FORK NEEDS TO BE ADDED BASED ON BAN-ONLY CONDITION
       backLink: 'immigration-detention'
     },
     '/exception': {

--- a/apps/ima/sections/summary-data-sections.js
+++ b/apps/ima/sections/summary-data-sections.js
@@ -224,6 +224,17 @@ module.exports = {
           return req.sessionModel.get('temporary-permission') === 'yes' ?
             list + '\nDetails added' : list;
         }
+      },
+      {
+        step: '/temporary-permission',
+        field: 'temporary-permission-details-ban-only',
+        parse: (list, req) => {
+          if (!req.sessionModel.get('steps').includes('/temporary-permission')) {
+            return null;
+          }
+          return (typeof req.sessionModel.get('temporary-permission-details-ban-only') !== 'undefined') ?
+            'Details added' : list;
+        }
       }
     ]
   },

--- a/apps/ima/views/temporary-permission.html
+++ b/apps/ima/views/temporary-permission.html
@@ -1,7 +1,7 @@
 {{<partials-page}}
   {{$page-content}}
     <p class="govuk-body">Do not use this question to make an asylum claim. Any asylum claim will be inadmissible.</p>
-    {{#t}}fields.temporary-permission-reasons-ban-only.legend{{/t}}
+    <strong>{{#t}}fields.temporary-permission-reasons-ban-only.label{{/t}}</strong>
     <p class="govuk-body">Any reasons given may not prevent you being removed from the UK.</p>
     {{#renderField}}temporary-permission-reasons-ban-only{{/renderField}}
     {{#renderField}}temporary-permission-details-ban-only{{/renderField}}


### PR DESCRIPTION
## What
- Amend the 'Information you have given us' (`final-summary`) page to include the `temporary-permission` screen section, as part of the DTR/ban-only flow [IMB-45](https://collaboration.homeoffice.gov.uk/jira/browse/IMB-45)

## Why
- For the user to be able to view information they have provided for the DTR/ban-only flow
- For the content to match the Figma designs

## How
- Add new section to /sections/summary-data-sections.js for the `temporary-permission` screen
- Add conditional logic to summary-data-sections.js to determine the value to be displayed in the temporary permission section
- Add the DTR/ban-only temporary permission page's field into pages.json
- Add conditional logic to the `immigration-detention` and `medical-records` pages in index.js, to enable the flow to fork based on the duty to remove alert value, where the duty to remove value and ban only are conversely related (e.g. if the dtr value is 'yes', then it should go down the ban-only 'no' route)

## Testing
- Tests passing locally