### PR TITLE
IMB-92 Validation on fullname

### DIFF
--- a/apps/ima/fields/index.js
+++ b/apps/ima/fields/index.js
@@ -31,7 +31,7 @@ module.exports = {
   },
   name: {
     labelClassName: 'visuallyhidden',
-    validate: ['required'],
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: [200] }],
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
   'current-email': {

--- a/apps/ima/translations/src/en/validation.json
+++ b/apps/ima/translations/src/en/validation.json
@@ -5,6 +5,10 @@
   "in-the-uk": {
     "required": "You must select an option"
   },
+  "full-name": {
+    "required": "Enter your full name",
+    "notUrl": "Please do not enter a link/url into your answers"
+  },
   "helper-fullname": {
     "required": "Enter your full name",
     "notUrl": "Please do not enter a link/url into your answers"


### PR DESCRIPTION
## What
- Validation on Full Name [IMB-92](https://collaboration.homeoffice.gov.uk/jira/browse/IMB-92)

## Why
- Validation on fullname Enter Full Name as URL or email format still accepted, and no error is shown  in you-location  flow

## How
- NoURL is added as validation in fields / index.js
- In validation.json file error messages were added to name 


## Testing
- Tests passing locally
