### PR TITLE
IMB-87-89: Add CEPR/DOB verification and set 'duty to remove alert' value in session

### DIFF
--- a/apps/ima/behaviours/check-email-token.js
+++ b/apps/ima/behaviours/check-email-token.js
@@ -10,13 +10,13 @@ module.exports = superclass => class extends superclass {
     const skipEmail = config.login.skipEmail;
     const skipEmailAuth = token === 'skip' && config.login.allowSkip && skipEmail;
     const validEmailToken = req.sessionModel.get('valid-token') === true;
-    const id = _.get(req.session['hof-wizard-verify'], 'uan');
+    const id = _.get(req.session['hof-wizard-verify'], 'cepr');
     // skips if it goes to /ima/start?token=skip
     // skips if a session is already present.
     if (skipEmailAuth && id) {
       req.sessionModel.set('valid-token', true);
       req.sessionModel.set('user-email', skipEmail);
-      req.sessionModel.set('uan', id);
+      req.sessionModel.set('cepr', id);
       req.sessionModel.set('date-of-birth', _.get(req.session['hof-wizard-verify'], 'date-of-birth'));
       return super.saveValues(req, res, next);
     }
@@ -32,7 +32,7 @@ module.exports = superclass => class extends superclass {
           req.sessionModel.set('valid-token', true);
           // store email to send to caseworker later
           req.sessionModel.set('user-email', user.email);
-          req.sessionModel.set('uan', user.uan);
+          req.sessionModel.set('cepr', user.cepr);
           req.sessionModel.set('date-of-birth', user['date-of-birth']);
           return super.saveValues(req, res, next);
         }

--- a/apps/ima/behaviours/continue-report.js
+++ b/apps/ima/behaviours/continue-report.js
@@ -19,9 +19,9 @@ const getMandatorySteps = (mandatorySteps, steps) => {
 
 module.exports = superclass => class extends superclass {
   getValues(req, res, next) {
-    const uan = req.sessionModel.get('uan');
+    const cepr = req.sessionModel.get('cepr');
 
-    if (!uan) {
+    if (!cepr) {
       return res.redirect('/ima/continue-form');
     }
 

--- a/apps/ima/behaviours/resume-form-session.js
+++ b/apps/ima/behaviours/resume-form-session.js
@@ -43,9 +43,9 @@ module.exports = superclass => class extends superclass {
 
         const cases = _.unionBy(parsedBody, sessionCases, 'id');
 
-        const uan = req.sessionModel.get('uan');
+        const cepr = req.sessionModel.get('cepr');
         const singleCase = cases.length < 2;
-        const isSameCase = _.get(cases, "[0].session['uan']") === uan;
+        const isSameCase = _.get(cases, "[0].session['cepr']") === cepr;
         const noCaseOrSameCase = !cases[0] || isSameCase;
         const multipleCasesInSession = _.get(req.sessionModel.get('user-cases'), 'length') > 1;
 
@@ -57,7 +57,7 @@ module.exports = superclass => class extends superclass {
           return res.redirect(super.getNextStep(req, res, next));
         }
 
-        const filteredCases = this.addCasesToSession(req, cases, uan);
+        const filteredCases = this.addCasesToSession(req, cases, cepr);
         this.setupRadioButtons(req, filteredCases);
 
         return super.configure(req, res, next);
@@ -65,19 +65,19 @@ module.exports = superclass => class extends superclass {
       .catch(next);
   }
 
-  addCasesToSession(req, cases, uan) {
-    const caseAlreadyInSession = cases.find(obj => obj.session.uan === uan);
+  addCasesToSession(req, cases, cepr) {
+    const caseAlreadyInSession = cases.find(obj => obj.session.cepr === cepr);
 
     if (!caseAlreadyInSession) {
       this.addSessionCaseToList(req, cases);
     }
 
-    const filteredCases = cases.filter(uanCase => {
+    const filteredCases = cases.filter(ceprCase => {
       const isDuplicate = cases.filter(obj => {
-        return obj.session.uan === uanCase.session.uan;
+        return obj.session.cepr === ceprCase.session.cepr;
       }).length > 1;
 
-      return uanCase.id || (!uanCase.id && !isDuplicate);
+      return ceprCase.id || (!ceprCase.id && !isDuplicate);
     });
 
     req.sessionModel.set('user-cases', filteredCases);
@@ -99,12 +99,12 @@ module.exports = superclass => class extends superclass {
     let cases = body;
 
     if (cases.length) {
-      cases = cases.map(uanCase => {
-        const session = uanCase.session;
-        uanCase.session = typeof session === 'string' ?
+      cases = cases.map(ceprCase => {
+        const session = ceprCase.session;
+        ceprCase.session = typeof session === 'string' ?
           JSON.parse(session) : session;
 
-        return uanCase;
+        return ceprCase;
       });
     }
     return cases;
@@ -112,29 +112,29 @@ module.exports = superclass => class extends superclass {
   // POST lifecycle
   saveValues(req, res, next) {
     const cases = req.sessionModel.get('user-cases');
-    const uanCase = cases.find(obj => obj.session.uan === req.form.values.uan);
+    const ceprCase = cases.find(obj => obj.session.cepr === req.form.values.cepr);
 
-    if (uanCase) {
-      req.sessionModel.set('id', uanCase.id);
+    if (ceprCase) {
+      req.sessionModel.set('id', ceprCase.id);
     }
 
-    this.setupSession(req, uanCase.session);
+    this.setupSession(req, ceprCase.session);
     req.sessionModel.set('multipleCases', true);
 
     return super.saveValues(req, res, next);
   }
 
   setupRadioButtons(req, cases) {
-    req.form.options.fields.uan = {
+    req.form.options.fields.cepr = {
       mixin: 'radio-group',
       isPageHeading: true,
       validate: ['required'],
       options: cases.map(obj => {
-        const uan = obj.session.uan;
+        const cepr = obj.session.cepr;
         const dob = obj.session['date-of-birth'];
         return {
-          label: `UAN: ${uan}`,
-          value: uan,
+          label: `CEPR: ${cepr}`,
+          value: cepr,
           useHintText: true,
           hint: `Date of birth ${moment(dob, 'YYYY-MM-DD').format('DD/MM/YYYY')}`
         };
@@ -142,8 +142,8 @@ module.exports = superclass => class extends superclass {
     };
   }
 
-  setupSession(req, uanCase) {
-    const session = uanCase;
+  setupSession(req, ceprCase) {
+    const session = ceprCase;
     const cases = req.sessionModel.get('user-cases');
     // ensure no /edit steps are add to the steps property when session resumed
     session.steps = session.steps.filter(step => !step.match(/\/change|edit$/));

--- a/apps/ima/behaviours/save-form-session.js
+++ b/apps/ima/behaviours/save-form-session.js
@@ -38,8 +38,9 @@ module.exports = superclass => class extends superclass {
 
       const id = req.sessionModel.get('id');
       const email = req.sessionModel.get('user-email');
-      const uan = req.sessionModel.get('uan');
+      const cepr = req.sessionModel.get('cepr');
       const date_of_birth = req.sessionModel.get('date-of-birth');
+      const duty_to_remove_alert = req.sessionModel.get('duty-to-remove-alert');
 
       req.log('info', `Saving Form Session: ${id}`);
 
@@ -47,7 +48,7 @@ module.exports = superclass => class extends superclass {
         const response = await axios({
           url: id ? applicationsUrl + `/${id}` : applicationsUrl,
           method: id ? 'PATCH' : 'POST',
-          data: id ? { session } : { session, email, uan, date_of_birth }
+          data: id ? { session } : { session, email, cepr, date_of_birth, duty_to_remove_alert }
         });
 
         const resBody = response.data;
@@ -87,7 +88,7 @@ module.exports = superclass => class extends superclass {
 
         return next();
       } catch (e) {
-        return next(e);
+        return next(e.response.data);
       }
     });
   }

--- a/apps/ima/index.js
+++ b/apps/ima/index.js
@@ -174,11 +174,21 @@ module.exports = {
           }
         },
         {
-        // TODO - TARGET AND CONDITION MUST BE CHANGED BASED ON BAN-ONLY CONDITION
           target: '/temporary-permission',
-          condition: {
-            fields: 'has-address',
-            value: 'no'
+          condition: req => {
+            if (req.sessionModel.get('has-address') === 'no' && req.sessionModel.get('duty-to-remove-alert') === 'yes') {
+              return true;
+            }
+            return false;
+          }
+        },
+        {
+          target: '/exception',
+          condition: req => {
+            if (req.sessionModel.get('has-address') === 'no' && req.sessionModel.get('duty-to-remove-alert') === 'no') {
+              return true;
+            }
+            return false;
           }
         }
       ],
@@ -192,7 +202,6 @@ module.exports = {
       ],
       locals: { showSaveAndExit: true },
       continueOnEdit: true,
-      next: '/medical-records', // TODO - URL MUST BE CHANGED BASED ON BAN-ONLY CONDITION
       backLink: 'phone-number'
     },
     '/medical-records': {

--- a/apps/ima/models/cases.js
+++ b/apps/ima/models/cases.js
@@ -23,7 +23,7 @@ module.exports = class Cases {
     return new Promise((resolve, reject) => {
       const params = {
         Bucket: config.aws.bucket,
-        Key: `uans/${this.s3Id}`
+        Key: `ceprs/${this.s3Id}`
       };
       const dataFile = path.join(__dirname + `../../../../data/${this.s3Id}.xlsx`);
       this.#createOrResetFile(dataFile);
@@ -41,7 +41,7 @@ module.exports = class Cases {
     let json = XLSXProcessor(this.s3Id);
 
     if (config.env !== 'production') {
-      json = json.concat(config.casesIds.testCases);
+      json = json.concat(config.casesIds.testCEPRCases);
     }
     const jsonFile = path.join(__dirname + `../../../../data/${this.s3Id}.json`);
     return fs.writeFile(jsonFile, JSON.stringify(json), console.log);

--- a/apps/ima/sections/summary-data-sections.js
+++ b/apps/ima/sections/summary-data-sections.js
@@ -6,8 +6,8 @@ module.exports = {
   'case-details': {
     steps: [
       {
-        step: '/uan',
-        field: 'uan',
+        step: '/cepr',
+        field: 'cepr',
         omitChangeLink: true
       },
       {

--- a/apps/ima/translations/src/en/fields.json
+++ b/apps/ima/translations/src/en/fields.json
@@ -1,5 +1,5 @@
 {
-  "uan": {
+  "cepr": {
     "legend": "Which form do you need to continue?"
   },
   "who-are-you": {

--- a/apps/ima/translations/src/en/pages.json
+++ b/apps/ima/translations/src/en/pages.json
@@ -139,8 +139,8 @@
       }
     },
     "fields": {
-      "uan": {
-        "label": "Unique Application Number (UAN)"
+      "cepr": {
+        "label": "CEPR"
       },
       "name": {
         "label": "Full name"

--- a/apps/ima/views/cases.html
+++ b/apps/ima/views/cases.html
@@ -1,6 +1,6 @@
 {{<partials-page}}
   {{$page-content}}
-    {{#renderField}}uan{{/renderField}}
+    {{#renderField}}cepr{{/renderField}}
     {{#input-submit}}continue-only{{/input-submit}}
   {{/page-content}}
 {{/partials-page}}

--- a/apps/ima/views/content/form-submitted.md
+++ b/apps/ima/views/content/form-submitted.md
@@ -7,6 +7,6 @@ If you have been given a claim period and need to send evidence after the end of
 </div>
 Do not wait for confirmation that you have been granted an extension to send your evidence.
 
-Your email subject line must contain the Unique application number {{values.uan}} and date of birth you used to sign in to this form.
+Your email subject line must contain the CEPR {{values.cepr}} and date of birth you used to sign in to this form.
 
 Information about how to send more evidence is also on the email we send you when you submitted this form.

--- a/apps/verify/behaviours/send-verification-email.js
+++ b/apps/verify/behaviours/send-verification-email.js
@@ -48,7 +48,7 @@ module.exports = superclass => class extends superclass {
     if (this.skipEmailVerification(email)) {
       return super.saveValues(req, res, next);
     }
-    const response = await axios.get(baseUrl + '/uan/' + req.sessionModel.get('uan'));
+    const response = await axios.get(baseUrl + '/cepr/' + req.sessionModel.get('cepr'));
     const claimantRecords = response.data;
     const recordEmail = claimantRecords.map(f => { return f.email; });
     const unSubmittedCase = _.filter(response.data, record => !record.submitted_at);

--- a/apps/verify/behaviours/validate-case-details.js
+++ b/apps/verify/behaviours/validate-case-details.js
@@ -10,11 +10,11 @@ module.exports = superclass => class extends superclass {
 
   isValidCase(req) {
     const casesJson = require(`../../../data/${config.casesIds.S3Id}.json`);
-    const uan = req.form.values.uan;
+    const cepr = req.form.values.cepr;
     const dob = req.form.values['date-of-birth'];
 
     const imaResult = casesJson.find(
-      obj => obj.uan === uan && obj['date-of-birth'] === dob);
+      obj => obj.cepr === cepr && obj['date-of-birth'] === dob);
     req.sessionModel.set('service', 'ima');
     return imaResult;
   }

--- a/apps/verify/fields/index.js
+++ b/apps/verify/fields/index.js
@@ -3,12 +3,12 @@
 const dateComponent = require('hof').components.date;
 const UANRef = {
   type: 'regex',
-  arguments: /^(\d{4}-\d{4}-\d{4}-\d{4}(?:\/\d{2})?)$/
+  arguments: /^([0-9]{6,10}?)$/
 };
 const after1900Validator = { type: 'after', arguments: ['1900'] };
 
 module.exports = {
-  uan: {
+  cepr: {
     labelClassName: 'visuallyhidden',
     validate: [
       'required',

--- a/apps/verify/index.js
+++ b/apps/verify/index.js
@@ -8,7 +8,7 @@ module.exports = {
   steps: {
     '/your-details': {
       behaviours: [ValidateCaseDetails],
-      fields: ['uan', 'date-of-birth'],
+      fields: ['cepr', 'date-of-birth'],
       next: '/enter-email'
     },
     '/details-not-found': {

--- a/apps/verify/translations/src/en/fields.json
+++ b/apps/verify/translations/src/en/fields.json
@@ -1,7 +1,7 @@
 {
-  "uan": {
-    "label": "Unique Application Number (UAN)",
-    "hint": "For example, 1234-5678-1234-5678"
+  "cepr": {
+    "label": "CEPR",
+    "hint": "For example, 8456463749"
   },
   "date-of-birth": {
     "legend": "Date of birth",

--- a/apps/verify/translations/src/en/validation.json
+++ b/apps/verify/translations/src/en/validation.json
@@ -1,8 +1,8 @@
 {
-  "uan": {
-    "required": "Enter your UAN reference",
-    "regex": "Enter a valid UAN. For example, 3455-9874-2349-0753 or 3455-9874-2349-0753/01",
-    "noUanRecordMatch": "Your UAN does not match our records, Check you have entered the UAN correctly"
+  "cepr": {
+    "required": "Enter your CEPR reference",
+    "regex": "Enter a valid CEPR. For example, 8456463749",
+    "noceprRecordMatch": "Your CEPR does not match our records, Check you have entered the CEPR correctly"
   },
   "date-of-birth": {
     "required": "Enter your date of birth",
@@ -12,6 +12,6 @@
   },
   "user-email": {
     "required": "Enter your email address",
-    "noRecordMatch": "Your email does not match the UAN given. Please enter the correct email"
+    "noRecordMatch": "Your email does not match the CEPR given. Please enter the correct email"
   }
 }

--- a/apps/verify/views/content/not-found.md
+++ b/apps/verify/views/content/not-found.md
@@ -1,5 +1,5 @@
-The Unique Application Number (UAN) and date of birth must exactly match what is on your Illegal Migration Act notice.
+The CEPR and date of birth must exactly match what is on your Illegal Migration Act notice.
 
-Check your UAN and date of birth, and try again.
+Check your CEPR and date of birth, and try again.
 
 You may need to wait up to 24 hours before starting this form to allow time for your details to be added to our system.

--- a/apps/verify/views/your-details.html
+++ b/apps/verify/views/your-details.html
@@ -1,11 +1,11 @@
 {{<partials-page}} 
 {{$page-content}} 
-  <div class="govuk-form-group {{#errors.uan}}govuk-form-group--error{{/errors.uan}}">
-    <label class="govuk-label" for="uan">
-      <strong>{{#t}}fields.uan.label{{/t}}</strong>
+  <div class="govuk-form-group {{#errors.cepr}}govuk-form-group--error{{/errors.cepr}}">
+    <label class="govuk-label" for="cepr">
+      <strong>{{#t}}fields.cepr.label{{/t}}</strong>
     </label>
     <p class="details-uan-dob">Find this on the Illegal Migration Act notice given to you by the Home Office.</p>
-    {{#input-text}}uan{{/input-text}}
+    {{#input-text}}cepr{{/input-text}}
   </div>
 
   <div

--- a/bin/upload_cases_sheet.sh
+++ b/bin/upload_cases_sheet.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 set -e
 
-aws s3 cp --sse aws:kms --sse-kms-key-id $AWS_KMS_KEY_ID ../data/$1.xlsx s3://$AWS_BUCKET/uans/$1
+aws s3 cp --sse aws:kms --sse-kms-key-id $AWS_KMS_KEY_ID ../data/$1.xlsx s3://$AWS_BUCKET/ceprs/$1
 # aws s3 rm s3://$AWS_BUCKET/uans/$1.xlsx
 # aws s3 cp --sse aws:kms --sse-kms-key-id $AWS_KMS_KEY_ID s3://$AWS_BUCKET/uans/$1 ./$1.xlsx

--- a/config.js
+++ b/config.js
@@ -19,7 +19,7 @@ module.exports = {
   casesIds: {
     uanValidLength: 19,
     cronEnabled: process.env.CRON_ENABLED,
-    S3Id: process.env.CASES_S3_ID || 'uans-data-2023-11-16',
+    S3Id: process.env.CASES_S3_ID || 'ceprs-data-2023-02-05',
     testCases: [{
       uan: '0000-0000-0000-0000', 'date-of-birth': '2000-01-01'
     }, {
@@ -36,6 +36,23 @@ module.exports = {
       uan: '0000-0000-0000-0006', 'date-of-birth': '2000-01-01'
     }, {
       uan: '0000-0000-0000-0007', 'date-of-birth': '2000-01-01'
+    }],
+    testCEPRCases: [{
+      cepr: '0000000001', 'date-of-birth': '2000-01-01', 'duty-to-remove-alert': 'yes'
+    }, {
+      cepr: '0000000002', 'date-of-birth': '2000-01-01', 'duty-to-remove-alert': 'no'
+    }, {
+      cepr: '0000000003', 'date-of-birth': '2000-01-01', 'duty-to-remove-alert': 'yes'
+    }, {
+      cepr: '0000000004', 'date-of-birth': '2000-01-01', 'duty-to-remove-alert': 'yes'
+    }, {
+      cepr: '0000000005', 'date-of-birth': '2000-01-01', 'duty-to-remove-alert': 'yes'
+    }, {
+      cepr: '0000000006', 'date-of-birth': '2000-01-01', 'duty-to-remove-alert': 'yes'
+    }, {
+      cepr: '0000000007', 'date-of-birth': '2000-01-01', 'duty-to-remove-alert': 'yes'
+    }, {
+      cepr: '0000000008', 'date-of-birth': '2000-01-01', 'duty-to-remove-alert': 'no'
     }]
   },
   csp: {
@@ -109,7 +126,7 @@ module.exports = {
   },
   sessionDefaults: {
     steps: ['/start', '/continue-form', '/summary', '/who-are-you'],
-    fields: ['user-email', 'uan', 'date-of-birth', 'csrf-secret', 'errorValues', 'errors']
+    fields: ['user-email', 'cepr', 'date-of-birth', 'csrf-secret', 'errorValues', 'errors']
   },
   ceprUpload: {
     recordScanLimit: 1,

--- a/db/get-token.js
+++ b/db/get-token.js
@@ -11,8 +11,9 @@ const read = async token => {
   const user = {};
   user.valid = await redis.get(`token:${token}`);
   user.email = await redis.get(`${token}:email`);
-  user.uan = await redis.get(`${token}:uan`);
+  user.cepr = await redis.get(`${token}:cepr`);
   user['date-of-birth'] = await redis.get(`${token}:date-of-birth`);
+  user['duty-to-remove-alert'] = await redis.get(`${token}:duty-to-remove-alert`);
 
   return user;
 };

--- a/db/save-token.js
+++ b/db/save-token.js
@@ -9,12 +9,14 @@ module.exports = {
     const token = uuidv1();
     redis.set(`token:${token}`, token);
     redis.set(`${token}:email`, email);
-    redis.set(`${token}:uan`, req.sessionModel.get('uan'));
+    redis.set(`${token}:cepr`, req.sessionModel.get('cepr'));
     redis.set(`${token}:date-of-birth`, req.sessionModel.get('date-of-birth'));
+    redis.set(`${token}:duty-to-remove-alert`, req.sessionModel.get('duty-to-remove-alert'));
     redis.expire(`token:${token}`, tokenExpiry);
     redis.expire(`${token}:email`, tokenExpiry);
-    redis.expire(`${token}:uan`, tokenExpiry);
+    redis.expire(`${token}:cepr`, tokenExpiry);
     redis.expire(`${token}:date-of-birth`, tokenExpiry);
+    redis.expire(`${token}:duty-to-remove-alert`, tokenExpiry);
 
     return token;
   }

--- a/lib/xlsx-processor.js
+++ b/lib/xlsx-processor.js
@@ -1,13 +1,10 @@
 
 const XLSX = require('xlsx');
 const moment = require('moment');
-const config = require('../config');
 // Yep. You'd think it would be days counted from 31st, but due to a known Lotus bug being carried over
 // to Excel back in the 1990s. All Excel raw data date integers are counted from this day. Who knew.
 // This comment is put here for anyone's reference, other than unit tests, so that noone thinks it's a bug.
 const excelStartDate = moment('1899-12-30', 'YYYY-MM-DD');
-
-const UAN_VALID_LENGTH = config.casesIds.uanValidLength;
 
 const cleanupString = str => {
   return str.toLowerCase().replace(/[^a-zA-Z]+/g, '');
@@ -22,16 +19,18 @@ const mapJsonValues = json => {
         // keys cleaned up if future excel sheets change case, use -/_ instead of spaces in key names etc
         const cleanedUpKey = cleanupString(key);
 
-        if (cleanedUpKey.startsWith('uan')) {
+        if (cleanedUpKey.startsWith('cepr')) {
           // ids come in as integers from excel raw data
           // as a precaution, padded zeros inserted so uans are correct length
-          const uan = obj[key].toString();
-          newObj.uan = uan.length < UAN_VALID_LENGTH ?
-            String('0'.repeat(UAN_VALID_LENGTH) + uan).slice(-UAN_VALID_LENGTH) : uan;
-        } else if (cleanedUpKey.startsWith('dateofbirth')) {
+          const cepr = obj[key].toString();
+          newObj.cepr = cepr;
+        } else if (cleanedUpKey.startsWith('dob')) {
           // dates come in as integers from excel raw data representing days since '1899-12-30'
           // we convert them to a consistent date string format to validate against user input
           newObj['date-of-birth'] = excelStartDate.clone().add(obj[key], 'days').format('YYYY-MM-DD');
+        } else if (cleanedUpKey.startsWith('dutytoremovealert')) {
+          const dutyToRemoveAlert = obj[key].toString();
+          newObj['duty-to-remove-alert'] = dutyToRemoveAlert;
         }
       }
     }

--- a/test/_unit/db/get-token.spec.js
+++ b/test/_unit/db/get-token.spec.js
@@ -25,14 +25,16 @@ describe('db/get-token', () => {
       const token = 'test';
       redis.get.withArgs('token:test').returns(token);
       redis.get.withArgs('test:email').returns('s@mail.com');
-      redis.get.withArgs('test:uan').returns('1234-5678-9101-1121');
+      redis.get.withArgs('test:cepr').returns('1234567890');
       redis.get.withArgs('test:date-of-birth').returns('2000/01/01');
+      redis.get.withArgs('test:duty-to-remove-alert').returns('true');
 
       const expected = {
         valid: 'test',
         email: 's@mail.com',
-        uan: '1234-5678-9101-1121',
-        'date-of-birth': '2000/01/01'
+        cepr: '1234567890',
+        'date-of-birth': '2000/01/01',
+        'duty-to-remove-alert': 'true'
       };
 
       try {
@@ -49,8 +51,9 @@ describe('db/get-token', () => {
       const expected = {
         valid: undefined,
         email: undefined,
-        uan: undefined,
-        'date-of-birth': undefined
+        cepr: undefined,
+        'date-of-birth': undefined,
+        'duty-to-remove-alert': undefined
       };
 
       try {

--- a/test/_unit/ima/behaviours/check-email-token.spec.js
+++ b/test/_unit/ima/behaviours/check-email-token.spec.js
@@ -85,7 +85,7 @@ describe('apps/ima/behaviours/check-email-token', () => {
 
     describe('bypasses email authentication', () => {
       it('when we provide a skip token, allowSkip, & skip email environment variable', () => {
-        req.session['hof-wizard-verify'].uan = '1904-5678-9101-1121';
+        req.session['hof-wizard-verify'].cepr = '1904-5678-9101-1121';
         req.query = {
           token: 'skip'
         };
@@ -107,7 +107,7 @@ describe('apps/ima/behaviours/check-email-token', () => {
 
     describe('when it bypasses the email authentication', () => {
       it('sets the user email based on the email params if it bypasses the email authentication', () => {
-        req.session['hof-wizard-verify'].uan = '1904-5678-9101-1121';
+        req.session['hof-wizard-verify'].cepr = '1904-5678-9101-1121';
         req.session['hof-wizard-verify']['date-of-birth'] = '2000/01/01';
         req.query = {
           token: 'skip'
@@ -116,12 +116,12 @@ describe('apps/ima/behaviours/check-email-token', () => {
         configStub.login.allowSkip = true;
         instance.saveValues(req, res);
         expect(sessionModel.set).to.have.been.calledWith('user-email', 'wanda@mail.com');
-        expect(sessionModel.set).to.have.been.calledWith('uan', '1904-5678-9101-1121');
+        expect(sessionModel.set).to.have.been.calledWith('cepr', '1904-5678-9101-1121');
         expect(sessionModel.set).to.have.been.calledWith('date-of-birth', '2000/01/01');
       });
 
       it('sets the user email based on the skipEmail environment variable if', () => {
-        req.session['hof-wizard-verify'].uan = '1234-5678-9101-1121';
+        req.session['hof-wizard-verify'].cepr = '1234-5678-9101-1121';
         req.session['hof-wizard-verify']['date-of-birth'] = '2000/01/01';
         req.query = {
           token: 'skip'
@@ -130,7 +130,7 @@ describe('apps/ima/behaviours/check-email-token', () => {
         configStub.login.skipEmail = 'pparker@gmail.com';
         instance.saveValues(req, res);
         expect(sessionModel.set).to.have.been.calledWith('user-email', 'pparker@gmail.com');
-        expect(sessionModel.set).to.have.been.calledWith('uan', '1234-5678-9101-1121');
+        expect(sessionModel.set).to.have.been.calledWith('cepr', '1234-5678-9101-1121');
         expect(sessionModel.set).to.have.been.calledWith('date-of-birth', '2000/01/01');
       });
     });

--- a/test/_unit/verify/behaviours/send-verification-email.spec.js
+++ b/test/_unit/verify/behaviours/send-verification-email.spec.js
@@ -98,7 +98,7 @@ describe('apps/verify/behaviours/send-verification-email', () => {
 
     it('sends an email for an application', done => {
       req.get.withArgs('host').returns('localhost');
-      req.sessionModel.get.withArgs('uan').returns('1876-1234-1234-5678');
+      req.sessionModel.get.withArgs('cepr').returns('1876-1234-1234-5678');
       const data = [];
       axiosGetStub.resolves({ data: data });
       req.form.values['user-email'] = 'buzz@lightyear.co.uk';
@@ -117,7 +117,7 @@ describe('apps/verify/behaviours/send-verification-email', () => {
           id: 12,
           created_at: '2023-10-09T17:51:38.339Z',
           updated_at: '2023-10-09T21:59:32.903Z',
-          uan: '9876-1234-1234-5678',
+          cepr: '9876-1234-1234-5678',
           email: 'marvel@test.com',
           date_of_birth: '2000/01/01',
           session: '{}',


### PR DESCRIPTION
## What
- Add CEPR/DOB verification to the beginning of the IMA form [IMB-87](https://collaboration.homeoffice.gov.uk/jira/browse/IMB-87)
- Change configuration of the database, replacing 'uan' with 'cepr', and adding the new column 'duty-to-remove-alert' [IMB-88](https://collaboration.homeoffice.gov.uk/jira/browse/IMB-88)
- Set the 'Duty to Remove alert' value in the session [IMB-89](https://collaboration.homeoffice.gov.uk/jira/browse/IMB-89)

## Why
- To verify that the combination of CEPR and DOB exists
- To use the CEPR now instead of UAN (as part of the wider database changes to replace UAN with CEPR)
- To allow the ban-only/DTR forking in the form [IMB-85](https://collaboration.homeoffice.gov.uk/jira/browse/IMB-85), as designed in Figma

## How
- Modify validation to cater for CEPR (6-10 digits) in validation.json
- Replace instances of 'uan' with 'cepr' across the code
- Set the 'duty to remove' value in the session across the form (/behaviours/save-form-session.js, /behaviours/validate-case-details.js, /db/save-token.js)

## Testing
- Tests passing locally