### PR TITLE
IMB-85: Add ban-only / DtR branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM node:lts-alpine@sha256:19eaf41f3b8c2ac2f609ac8103f9246a6a6d46716cdbe49103fd
 
 USER root
 
-RUN apk update && apk upgrade --no-cache
+RUN apk update && apk upgrade --no-cache && \
+    apk add postgresql
 
 # Setup nodejs group & nodejs user
 RUN addgroup --system nodejs --gid 998 && \

--- a/apps/ima/behaviours/check-email-token.js
+++ b/apps/ima/behaviours/check-email-token.js
@@ -18,6 +18,7 @@ module.exports = superclass => class extends superclass {
       req.sessionModel.set('user-email', skipEmail);
       req.sessionModel.set('cepr', id);
       req.sessionModel.set('date-of-birth', _.get(req.session['hof-wizard-verify'], 'date-of-birth'));
+      req.sessionModel.set('duty-to-remove-alert', _.get(req.session['hof-wizard-verify'], 'duty-to-remove-alert'));
       return super.saveValues(req, res, next);
     }
 
@@ -34,6 +35,7 @@ module.exports = superclass => class extends superclass {
           req.sessionModel.set('user-email', user.email);
           req.sessionModel.set('cepr', user.cepr);
           req.sessionModel.set('date-of-birth', user['date-of-birth']);
+          req.sessionModel.set('duty-to-remove-alert', user['duty-to-remove-alert']);
           return super.saveValues(req, res, next);
         }
         return res.redirect(config.login.invalidTokenPath);

--- a/apps/ima/behaviours/resume-form-session.js
+++ b/apps/ima/behaviours/resume-form-session.js
@@ -116,6 +116,7 @@ module.exports = superclass => class extends superclass {
 
     if (ceprCase) {
       req.sessionModel.set('id', ceprCase.id);
+      req.sessionModel.set('duty-to-remove-alert', ceprCase['duty-to-remove-alert']);
     }
 
     this.setupSession(req, ceprCase.session);

--- a/apps/ima/behaviours/save-form-session.js
+++ b/apps/ima/behaviours/save-form-session.js
@@ -38,7 +38,7 @@ module.exports = superclass => class extends superclass {
 
       const id = req.sessionModel.get('id');
       const email = req.sessionModel.get('user-email');
-      const CEPR = req.sessionModel.get('cepr');
+      const cepr = req.sessionModel.get('cepr');
       const date_of_birth = req.sessionModel.get('date-of-birth');
       const duty_to_remove_alert = req.sessionModel.get('duty-to-remove-alert');
 
@@ -48,7 +48,7 @@ module.exports = superclass => class extends superclass {
         const response = await axios({
           url: id ? applicationsUrl + `/${id}` : applicationsUrl,
           method: id ? 'PATCH' : 'POST',
-          data: id ? { session } : { session, email, CEPR, date_of_birth, duty_to_remove_alert }
+          data: id ? { session } : { session, email, cepr, date_of_birth, duty_to_remove_alert }
         });
 
         const resBody = response.data;

--- a/apps/ima/behaviours/save-form-session.js
+++ b/apps/ima/behaviours/save-form-session.js
@@ -38,7 +38,7 @@ module.exports = superclass => class extends superclass {
 
       const id = req.sessionModel.get('id');
       const email = req.sessionModel.get('user-email');
-      const cepr = req.sessionModel.get('cepr');
+      const CEPR = req.sessionModel.get('cepr');
       const date_of_birth = req.sessionModel.get('date-of-birth');
       const duty_to_remove_alert = req.sessionModel.get('duty-to-remove-alert');
 
@@ -48,7 +48,7 @@ module.exports = superclass => class extends superclass {
         const response = await axios({
           url: id ? applicationsUrl + `/${id}` : applicationsUrl,
           method: id ? 'PATCH' : 'POST',
-          data: id ? { session } : { session, email, cepr, date_of_birth, duty_to_remove_alert }
+          data: id ? { session } : { session, email, CEPR, date_of_birth, duty_to_remove_alert }
         });
 
         const resBody = response.data;

--- a/apps/ima/translations/src/en/pages.json
+++ b/apps/ima/translations/src/en/pages.json
@@ -103,6 +103,9 @@
   "temporary-permission-to-stay": {
     "header": "Are there any other reasons you should be granted temporary permission to stay in the UK?"
   },
+  "temporary-permission": {
+    "header": "Why should you be granted temporary permission to stay in the UK?"
+  },
   "evidence-upload": {
     "header": "Upload evidence"
   },
@@ -201,6 +204,9 @@
       },
       "temporary-permission": {
         "label": "Request temporary permission to stay"
+      },
+      "temporary-permission-details-ban-only": {
+        "label": "Request for temporary permission to stay"
       },
       "images": {
         "label": "Files uploaded"

--- a/apps/verify/behaviours/validate-case-details.js
+++ b/apps/verify/behaviours/validate-case-details.js
@@ -15,6 +15,7 @@ module.exports = superclass => class extends superclass {
 
     const imaResult = casesJson.find(
       obj => obj.cepr === cepr && obj['date-of-birth'] === dob);
+    req.sessionModel.set('duty-to-remove-alert', imaResult['duty-to-remove-alert']);
     req.sessionModel.set('service', 'ima');
     return imaResult;
   }

--- a/apps/verify/behaviours/validate-case-details.js
+++ b/apps/verify/behaviours/validate-case-details.js
@@ -15,6 +15,7 @@ module.exports = superclass => class extends superclass {
 
     const imaResult = casesJson.find(
       obj => obj.cepr === cepr && obj['date-of-birth'] === dob);
+    req.form.values['duty-to-remove-alert'] = imaResult['duty-to-remove-alert'];
     req.sessionModel.set('duty-to-remove-alert', imaResult['duty-to-remove-alert']);
     req.sessionModel.set('service', 'ima');
     return imaResult;

--- a/config.js
+++ b/config.js
@@ -126,7 +126,7 @@ module.exports = {
   },
   sessionDefaults: {
     steps: ['/start', '/continue-form', '/summary', '/who-are-you'],
-    fields: ['user-email', 'cepr', 'date-of-birth', 'csrf-secret', 'errorValues', 'errors']
+    fields: ['user-email', 'cepr', 'date-of-birth', 'duty-to-remove-alert', 'csrf-secret', 'errorValues', 'errors']
   },
   ceprUpload: {
     recordScanLimit: 1,

--- a/kube/hof-rds-api/deployment.yml
+++ b/kube/hof-rds-api/deployment.yml
@@ -33,7 +33,7 @@ spec:
       containers:
         - name: data-service
           # release v2.0.1
-          image: quay.io/ukhomeofficedigital/hof-rds-api:f0fe62e70a22fbc28004b0d57f900b57e977d1de
+          image: quay.io/ukhomeofficedigital/hof-rds-api:4457d4a2f135439a3a5789a6fa251f8e8f9e24b9
           imagePullPolicy: Always
           envFrom:
             - configMapRef:

--- a/kube/hof-rds-api/deployment.yml
+++ b/kube/hof-rds-api/deployment.yml
@@ -46,7 +46,7 @@ spec:
             - name: SERVICE_NAME
               value: "ima"
             - name: LATEST_MIGRATION
-              value: "20240202143333_rename_uan_column_to_cepr"
+              # value: TO BE UPDATED WITH LATEST MIGRATION
             - name: MAX_PAYLOAD_SIZE
               value: "30mb"
             - name: REQUEST_TIMEOUT

--- a/kube/hof-rds-api/deployment.yml
+++ b/kube/hof-rds-api/deployment.yml
@@ -33,7 +33,7 @@ spec:
       containers:
         - name: data-service
           # release v2.0.1
-          image: quay.io/ukhomeofficedigital/hof-rds-api:ee9ea8ca6881fa8e50b1e8945a3f4d13bb355c5e
+          image: quay.io/ukhomeofficedigital/hof-rds-api:4457d4a2f135439a3a5789a6fa251f8e8f9e24b9
           imagePullPolicy: Always
           envFrom:
             - configMapRef:
@@ -46,7 +46,7 @@ spec:
             - name: SERVICE_NAME
               value: "ima"
             - name: LATEST_MIGRATION
-              # value: TO BE UPDATED WITH LATEST MIGRATION
+              value: "20240202143333_rename_uan_column_to_cepr"
             - name: MAX_PAYLOAD_SIZE
               value: "30mb"
             - name: REQUEST_TIMEOUT

--- a/kube/hof-rds-api/deployment.yml
+++ b/kube/hof-rds-api/deployment.yml
@@ -46,7 +46,7 @@ spec:
             - name: SERVICE_NAME
               value: "ima"
             - name: LATEST_MIGRATION
-              # value: TO BE UPDATED WITH LATEST MIGRATION
+              value: "20240202143333_rename_uan_column_to_cepr"
             - name: MAX_PAYLOAD_SIZE
               value: "30mb"
             - name: REQUEST_TIMEOUT

--- a/kube/hof-rds-api/deployment.yml
+++ b/kube/hof-rds-api/deployment.yml
@@ -33,7 +33,7 @@ spec:
       containers:
         - name: data-service
           # release v2.0.1
-          image: quay.io/ukhomeofficedigital/hof-rds-api:4457d4a2f135439a3a5789a6fa251f8e8f9e24b9
+          image: quay.io/ukhomeofficedigital/hof-rds-api:f0fe62e70a22fbc28004b0d57f900b57e977d1de
           imagePullPolicy: Always
           envFrom:
             - configMapRef:


### PR DESCRIPTION
## What
- Add ban-only / Duty to Remove branch to the IMA form flow [IMB-85](https://collaboration.homeoffice.gov.uk/jira/browse/IMB-85)

## Why
- To allow the ban-only/DTR forking in the form
- To match the flow designed on Figma

## How
- Get the 'duty to remove alert' value from the session in /db/get-token.js
- Add conditional logic to index.js, using the session's 'duty to remove alert' value, to determine the flow
- Update /kube/hof-rds-api/deployment.yml with the latest Quay image ID that contains the new database column change

## Testing
- Tests passing locally