### PR TITLE
IMB-116-page-does-not-exist-bug-fix

### DIFF
--- a/apps/ima/index.js
+++ b/apps/ima/index.js
@@ -275,7 +275,7 @@ module.exports = {
       locals: { showSaveAndExit: true },
       continueOnEdit: true,
       next: '/arrival-date',
-      backLink: '/exception'
+      backLink: 'exception'
     },
     '/without-permission': {
       behaviours: SaveFormSession,


### PR DESCRIPTION
## What
- Page not found bug fix [IMB-116](https://collaboration.homeoffice.gov.uk/jira/browse/IMB-116)

## Why
- When we press back button in removal-condition it goes to page not found instead of exception page

## How
-  Removed / in backlink and use exception  instead of /exception in removal-condition in index.js

## Testing
- Tests passing locally
