### PR TITLE
IMB-144: Update config for hof-db-table-replacer

### DIFF
--- a/kube/cron/hof_db_table_replacer.yaml
+++ b/kube/cron/hof_db_table_replacer.yaml
@@ -22,7 +22,7 @@ spec:
         spec:
           containers:
           - name: hof-db-table-replacer
-            image: quay.io/ukhomeofficedigital/hof-db-table-replacer@sha256:241e0d20f87f4dbeb988a026d0d84590edf65a4a3b8a1f46dd67592f919297b9
+            image: quay.io/ukhomeofficedigital/hof-db-table-replacer:d98604c8d6d3679ecc61d0bb55ac2015a144d5c8
             imagePullPolicy: Always
             securityContext:
               runAsNonRoot: true
@@ -72,7 +72,7 @@ spec:
                 valueFrom:
                   secretKeyRef:
                     name: keycloak-user
-                    key: password             
+                    key: password
               - name: DB_HOST
                 valueFrom:
                   secretKeyRef:
@@ -119,7 +119,10 @@ spec:
                 value: knex-postgres-model
               - name: SERVICE_NAME
                 value: ima
-#            command: ["yarn", "run", "generate:reports"]
+              - name: NOTIFICATIONS_CLIENT
+                value: govuk-notify
+              - name: NOTIFICATIONS_MODEL
+                value: govuk-notify-model
             resources:
               requests:
                 memory: 4Gi


### PR DESCRIPTION
## What?

- Add notify client and model names to environment
- Remove command property
- Update image to use latest working hof-db-table-replacer from quay

## Why?

Environment vars are new feature to allow selection of a Notifications client and model. The command property is not needed as `yarn start` is run in the Dockerfile once the image is built.

Latest image from quay has latest code updates to the script including DB table replacement and notification elements.
