### PR TITLE
IMB-144: Update hof-rds-api image and remove branch deployment of cronjobs

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -28,8 +28,7 @@ if [[ ${KUBE_NAMESPACE} == ${BRANCH_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml -f kube/certs
   $kd -f kube/file-vault/file-vault-ingress.yml -f kube/html-pdf
   $kd -f kube/redis -f kube/hof-rds-api  -f kube/file-vault
-  #Added cron to Branch for testing
-  $kd -f kube/app -f kube/cron
+  $kd -f kube/app
   $kd -f kube/autoscale/hpa-ima.yml
 elif [[ ${KUBE_NAMESPACE} == ${UAT_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml

--- a/kube/hof-rds-api/deployment.yml
+++ b/kube/hof-rds-api/deployment.yml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
         - name: data-service
-          image: quay.io/ukhomeofficedigital/hof-rds-api:c2783902927e73aa3449d82524bc5d9040e778e5
+          image: quay.io/ukhomeofficedigital/hof-rds-api:35dcb7c63abd23bc68bdd7beb8f9e885588f181a
           imagePullPolicy: Always
           envFrom:
             - configMapRef:

--- a/kube/hof-rds-api/deployment.yml
+++ b/kube/hof-rds-api/deployment.yml
@@ -45,7 +45,7 @@ spec:
             - name: SERVICE_NAME
               value: "ima"
             - name: LATEST_MIGRATION
-              value: "20240202143333_rename_uan_column_to_cepr"
+              value: "20240418094037_create_cepr_lookup"
             - name: MAX_PAYLOAD_SIZE
               value: "30mb"
             - name: REQUEST_TIMEOUT

--- a/kube/hof-rds-api/deployment.yml
+++ b/kube/hof-rds-api/deployment.yml
@@ -32,8 +32,7 @@ spec:
     spec:
       containers:
         - name: data-service
-          # release v2.0.1
-          image: quay.io/ukhomeofficedigital/hof-rds-api:4457d4a2f135439a3a5789a6fa251f8e8f9e24b9
+          image: quay.io/ukhomeofficedigital/hof-rds-api:c2783902927e73aa3449d82524bc5d9040e778e5
           imagePullPolicy: Always
           envFrom:
             - configMapRef:


### PR DESCRIPTION
## What?

- Update image used for hof-rds-api deployment.
- Remove the ability for branch environment to deploy cronjobs from `/kube/cron` folder
- Relates [IMB-144](https://collaboration.homeoffice.gov.uk/jira/browse/IMB-144)

## Why?

- The new image for hof-rds-api will allow the latest knex migration to run and add the new `cepr_lookup` table to the database. This new table is required for the hof-db-table-replacer to run.
- Cron jobs were enabled temporarily in branch env to test a new job and can now be removed to avoid spawning many identical jobs. 


## How?

Updated kubernetes deployment file for hof-rds-api and the generic `deploy.sh` script.
