### PR TITLE
IMB-144 Update hof-db-table-replacer to latest image

### DIFF
--- a/kube/cron/hof_db_table_replacer.yaml
+++ b/kube/cron/hof_db_table_replacer.yaml
@@ -22,7 +22,7 @@ spec:
         spec:
           containers:
           - name: hof-db-table-replacer
-            image: quay.io/ukhomeofficedigital/hof-db-table-replacer:d98604c8d6d3679ecc61d0bb55ac2015a144d5c8
+            image: quay.io/ukhomeofficedigital/hof-db-table-replacer:e0d59bb9dd3212434b16ebeb18661bd3e6c2d744
             imagePullPolicy: Always
             securityContext:
               runAsNonRoot: true


### PR DESCRIPTION
## What?

Update the image used for hof-db-table-replacer cron jobs to the latest created.

## Why?

This image is the master branch with all MVP supporting tickets merged into it.
