### PR TITLE
IMB-125: Remove PSQL from the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ FROM node:lts-alpine@sha256:19eaf41f3b8c2ac2f609ac8103f9246a6a6d46716cdbe49103fd
 
 USER root
 
-RUN apk update && apk upgrade --no-cache && \
-    apk add postgresql
+RUN apk update && apk upgrade --no-cache
 
 # Setup nodejs group & nodejs user
 RUN addgroup --system nodejs --gid 998 && \


### PR DESCRIPTION
## What?
Remove PSQL from the Dockerfile in IMA - [IMB-125](https://collaboration.homeoffice.gov.uk/jira/browse/IMB-125)

## Why?
To remove PSQL from the IMA UAT environment

## How?
Remove the '`apk add postgresql`' command from the Dockerfile

## Testing?
Tested for removal of PSQL in branch

## Screenshots (optional)
## Anything Else? (optional)
