### PR TITLE
IMB-26 Add https to fv urls in cron environment

### DIFF
--- a/kube/cron/generate_csv_reports.yaml
+++ b/kube/cron/generate_csv_reports.yaml
@@ -45,11 +45,11 @@ spec:
                     key: notify-key
               - name: FILE_VAULT_URL
               {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
-                value: fv-ima.sas.homeoffice.gov.uk/file
+                value: https://fv-ima.sas.homeoffice.gov.uk/file
               {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
-                value: fv-ima.stg.sas.homeoffice.gov.uk/file
+                value: https://fv-ima.stg.sas.homeoffice.gov.uk/file
               {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
-                value: fv-ima.uat.sas-notprod.homeoffice.gov.uk/file
+                value: https://fv-ima.uat.sas-notprod.homeoffice.gov.uk/file
               {{ else if eq .KUBE_NAMESPACE .BRANCH_ENV }}
                 value: https://fv-{{ .DRONE_SOURCE_BRANCH }}.branch.sas-notprod.homeoffice.gov.uk/file
               {{ end }}


### PR DESCRIPTION
## What?

Add 'https://' to some of the FILE_VAULT_URL values in the cron environment for the genrate_csv_urls job

## Why?

Job was failing and this was a difference in code between setup for ACQ's successful job and this one.

