### PR TITLE
IMB-29: Add PDF confirmation email to IMA

### DIFF
--- a/apps/ima/behaviours/submit.js
+++ b/apps/ima/behaviours/submit.js
@@ -13,9 +13,25 @@ module.exports = superclass => class extends superclass {
     uploadPdfShared.send(req, res, super.locals(req, res));
 
     const userEmail = req.sessionModel.get('user-email');
-    const userFormEmail = req.sessionModel.get('email-address-details');
-    const advisorEmail = req.sessionModel.get('legal-representative-email');
-    const allUniqueEmails = _.uniq([userEmail, userFormEmail, advisorEmail].filter(e => e));
+
+    // use either the email entered on the validation page or the one entered within the form
+    let userFormEmail = '';
+    if(req.sessionModel.get('current-email') === 'yes') {
+      userFormEmail = userEmail;
+    } else if(req.sessionModel.get('current-email') === 'no') {
+      userFormEmail = req.sessionModel.get('email-address-details');
+    }
+
+    let advisorEmail = '';
+    if(req.sessionModel.get('is-legal-representative-email') === 'yes') {
+      advisorEmail = userEmail;
+    } else if(req.sessionModel.get('is-legal-representative-email') === 'no') {
+      advisorEmail = req.sessionModel.get('legal-representative-email');
+    }
+
+    const claimsEmail = process.env.CLAIMS_EMAIL;
+
+    const allUniqueEmails = _.uniq([userEmail, userFormEmail, advisorEmail, claimsEmail].filter(e => e));
 
     req.sessionModel.set('all-unique-emails', allUniqueEmails);
 

--- a/apps/ima/translations/src/en/pages.json
+++ b/apps/ima/translations/src/en/pages.json
@@ -117,9 +117,6 @@
   "temporary-permission-to-stay": {
     "header": "Are there any other reasons you should be granted temporary permission to stay in the UK?"
   },
-  "temporary-permission": {
-    "header": "Why should you be granted temporary permission to stay in the UK?"
-  },
   "evidence-upload": {
     "header": "Upload evidence"
   },
@@ -245,8 +242,10 @@
   },
   "form-submitted": {
     "confirmed": "Form Submitted",
-    "paragraph1": "We have sent a copy of completed form to:",
+    "paragraph1": "We have sent a copy of your completed form to:",
     "header2": "What happens next",
-    "paragraph2": "We will make decision about your claim, then contact you to tell you what you need to do next."
+    "paragraph2": "We will email our decision on your claim to your immigration adviser. If you do not have one, we will send our decision directly to you by:",
+    "list1": "email",
+    "list2": "post, if you do not have email"
   }
 }

--- a/apps/ima/views/content/form-submitted.md
+++ b/apps/ima/views/content/form-submitted.md
@@ -1,12 +1,24 @@
+<ul class="govuk-list govuk-list--bullet">
+  <li>{{#t}}pages.form-submitted.list1{{/t}}</li>
+  <li>{{#t}}pages.form-submitted.list2{{/t}}</li>
+</ul>
+
+If your address changes, email your new address to IMAqueries@homeoffice.gov.uk
+
 ### If you need to send more evidence
 <div class="evidence-list">
 If you have been given a claim period and need to send evidence after the end of the period, you need to:
 
-1. apply for an extension at the end of your claim period
-2. send your evidence to [EMAIL ADDRESS] as soon as possible
+1. apply for an extension before the end end of your claim period
+2. send your evidence to IMAqueries@homeoffice.gov.uk as soon as possible
 </div>
+<br>
 Do not wait for confirmation that you have been granted an extension to send your evidence.
+<br>
+Your email subject line must contain the CEPR and date of birth you used to sign in to this form.
 
-Your email subject line must contain the CEPR {{values.cepr}} and date of birth you used to sign in to this form.
+Information about how to send more evidence is also in the email we sent you when you submitted this form.
 
-Information about how to send more evidence is also on the email we send you when you submitted this form.
+<p class="govuk-body">
+  <a href="#" class="govuk-link">Find out how to apply for an extension</a>.
+</p>

--- a/apps/ima/views/form-submitted.html
+++ b/apps/ima/views/form-submitted.html
@@ -1,7 +1,7 @@
 {{<partials-page}}
   {{$pageTitle}}{{#t}}pages.form-submitted.confirmed{{/t}} – GOV.UK{{/pageTitle}} 
   {{$page-content}}
-<!-- alert-complete is the HOF supported class currently, should be using the govuk-styles -->
+  <!-- alert-complete is the HOF supported class currently, should be using the govuk-styles -->
   <div class="govuk-panel alert-complete govuk-panel--confirmation">
     <h1 class="govuk-panel__title">
       {{#t}}pages.form-submitted.confirmed{{/t}}
@@ -17,7 +17,7 @@
 
   <h2 class="govuk-heading-m">{{#t}}pages.form-submitted.header2{{/t}}</h2>
   <p class="govuk-body">{{#t}}pages.form-submitted.paragraph2{{/t}}</p>
-    {{#markdown}}form-submitted.md{{/markdown}}
+  {{#markdown}}form-submitted.md{{/markdown}}
 
-    {{/page-content}}
-    {{/partials-page}}
+  {{/page-content}}
+  {{/partials-page}}

--- a/apps/ima/views/pdf.html
+++ b/apps/ima/views/pdf.html
@@ -12,7 +12,7 @@
   {{/head}}
   {{$main}}
     <main id="content" class="main" role="main">
-      <img src="{{ho-logo}}" alt="Home Office logo"/>
+      <img class="ho-logo" src="{{ho-logo}}" alt="Home Office logo"/>
       <h1>{{title}}</h1>
       <h2>Time and date: {{dateTime}}</h2>
       {{#rows}}

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -328,3 +328,13 @@ div > .section-header[data-content="Case details"]{
 .head-details {
   border-bottom: 1px;
 }
+
+// Styling for submission PDF
+.ho-logo {
+  padding-top: 30px;
+}
+
+.main {
+  padding-left: 15px;
+  padding-right: 15px;
+}

--- a/config.js
+++ b/config.js
@@ -5,7 +5,7 @@ const env = process.env.NODE_ENV || 'production';
 
 module.exports = {
   PRETTY_DATE_FORMAT: 'Do MMMM YYYY',
-  dateTimeFormat: 'DD MMM YYYY HH:mm:ss',
+  dateTimeFormat: 'D MMM YYYY HH:mm:ss',
   env: env,
   dataDirectory: './data',
   aws: {


### PR DESCRIPTION
## What?
Add functionality to send an email with a PDF on submission of the IMA form - [IMB-29](https://collaboration.homeoffice.gov.uk/jira/browse/IMB-29)

## Why?
For the IMA users to receive a confirmation email of the form submission including a PDF of their answers, with the email being sent to the immigration adviser too if they are specified on the form

## How?
- amend GovNotify submission email template to match the latest designs
- change `/behaviours/create-and-send-pdf.js` to use the updated GovNotify template and to pass it the correct parameters from the form, and to remove redundant logic
- amend `/behaviours/submit.js` to retrieve all the unique emails that are relevant for the email-sending functionality
- amend confirmation page's wording in `pages.json` and `form-submitted.md` to match the latest Figma designs and to apply govuk design classes
- amend the submission PDF content in 
- add CSS styling to the PDF in `/views/pdf.html` and `/assets/app.scss` to improve its design
- change the date time format for the PDF in `config.js` to remove the '0' for single digit days on the submission PDF

## Testing?
Tested locally and in branch

## Screenshots (optional)
### **Submission email:**
<img width="638" alt="image" src="https://github.com/UKHomeOffice/ima/assets/142597294/4b025b3d-3f13-46cb-a2d5-623d9687a157">

### **PDF attachment:**
<img width="552" alt="image" src="https://github.com/UKHomeOffice/ima/assets/142597294/d03d4bf3-a2ad-4bbd-960a-7a41d7474265">

## Anything Else? (optional)
