### PR TITLE
IMB-111: Update repo for using Stage env

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,7 @@ environment:
   STG_ENV: sas-ima-stg
   UAT_ENV: sas-ima-uat
   BRANCH_ENV: sas-ima-branch
-  # PRODUCTION_URL: TO BE UPDATED ONCE URL IS PROVIDED
+  PRODUCTION_URL: www.illegal-migration-act.homeoffice.gov.uk 
   IMAGE_URL: quay.io/ukhomeofficedigital
   IMAGE_REPO: ima
   GIT_REPO: UKHomeOffice/ima

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -40,7 +40,7 @@ elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml
   $kd -f kube/file-vault/file-vault-ingress.yml -f kube/html-pdf
   $kd -f kube/hof-rds-api -f kube/redis -f kube/file-vault
-  $kd -f kube/app
+  $kd -f kube/app -f kube/cron
   $kd -f kube/autoscale/hpa-ima.yml
 elif [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml  -f kube/app/service.yml

--- a/bin/image_check.sh
+++ b/bin/image_check.sh
@@ -3,4 +3,3 @@
 docker build -t test-repo-image:latest . || docker build -t test-repo-image:latest ..
 snyk config set api=$SNYK_TOKEN
 snyk container test test-repo-image
-curl -s https://ci-tools.anchore.io/inline_scan-latest | bash -s -- -r test-repo-image:latest

--- a/kube/app/deployment.yml
+++ b/kube/app/deployment.yml
@@ -124,7 +124,7 @@ spec:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
-                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) }}
+                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV)}}
                   name: ima-s3-bucket-secret
                   {{ else }}
                   name: ima-s3-prod
@@ -133,7 +133,7 @@ spec:
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) }}
+                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV)}}
                   name: ima-s3-bucket-secret
                   {{ else }}
                   name: ima-s3-prod
@@ -142,7 +142,7 @@ spec:
             - name: AWS_KMS_KEY_ID
               valueFrom:
                 secretKeyRef:
-                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) }}
+                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV)}}
                   name: ima-s3-bucket-secret
                   {{ else }}
                   name: ima-s3-prod
@@ -151,7 +151,7 @@ spec:
             - name: AWS_BUCKET
               valueFrom:
                 secretKeyRef:
-                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) }}
+                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV)}}
                   name: ima-s3-bucket-secret
                   {{ else }}
                   name: ima-s3-prod

--- a/kube/cron/hof_db_table_replacer.yaml
+++ b/kube/cron/hof_db_table_replacer.yaml
@@ -46,8 +46,8 @@ spec:
               - name: FILE_VAULT_URL
               {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
                 value: fv-ima.sas.homeoffice.gov.uk/file
-#              {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
-#                value: fv-ima.stg.sas.homeoffice.gov.uk/file
+              {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
+                value: fv-ima.stg.sas.homeoffice.gov.uk/file
               {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
                 value: fv-ima.uat.sas-notprod.homeoffice.gov.uk/file
               {{ else if eq .KUBE_NAMESPACE .BRANCH_ENV }}
@@ -77,37 +77,37 @@ spec:
                 valueFrom:
                   secretKeyRef:
                     key: endpoint
-                    {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) }}
+                    {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV)}}
                     name: ima-notprod-rds
                     {{ else }}
-                    name: ima-prod
+                    name: ima-rds-prod
                     {{ end }}
               - name: DB_NAME
                 valueFrom:
                   secretKeyRef:
                     key: db_name
-                    {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) }}
+                    {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV)}}
                     name: ima-notprod-rds
                     {{ else }}
-                    name: ima-prod
+                    name: ima-rds-prod
                     {{ end }}
               - name: DB_USER
                 valueFrom:
                   secretKeyRef:
                     key: username
-                    {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) }}
+                    {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV)}}
                     name: ima-notprod-rds
                     {{ else }}
-                    name: ima-prod
+                    name: ima-rds-prod
                     {{ end }}
               - name: DB_PASS
                 valueFrom:
                   secretKeyRef:
                     key: password
-                    {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) }}
+                    {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV)}}
                     name: ima-notprod-rds
                     {{ else }}
-                    name: ima-prod
+                    name: ima-rds-prod
                     {{ end }}
               - name: DB_PORT
                 value: "5432"

--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -84,7 +84,7 @@ spec:
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) }}
+                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV)}}
                   name: ima-s3-bucket-secret
                   {{ else }}
                   name: ima-s3-prod
@@ -93,7 +93,7 @@ spec:
             - name: AWS_KMS_KEY_ID
               valueFrom:
                 secretKeyRef:
-                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) }}
+                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV)}}
                   name: ima-s3-bucket-secret
                   {{ else }}
                   name: ima-s3-prod
@@ -102,7 +102,7 @@ spec:
             - name: AWS_BUCKET
               valueFrom:
                 secretKeyRef:
-                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) }}
+                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV)}}
                   name: ima-s3-bucket-secret
                   {{ else }}
                   name: ima-s3-prod

--- a/kube/hof-rds-api/deployment.yml
+++ b/kube/hof-rds-api/deployment.yml
@@ -56,37 +56,37 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: endpoint
-                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) }}
+                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV)}}
                   name: ima-notprod-rds
                   {{ else }}
-                  name: ima-prod
+                  name: ima-rds-prod
                   {{ end }}
             - name: DB_NAME
               valueFrom:
                 secretKeyRef:
                   key: db_name
-                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) }}
+                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV)}}
                   name: ima-notprod-rds
                   {{ else }}
-                  name: ima-prod
+                  name: ima-rds-prod
                   {{ end }}
             - name: DB_USER
               valueFrom:
                 secretKeyRef:
                   key: username
-                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) }}
+                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV)}}
                   name: ima-notprod-rds
                   {{ else }}
-                  name: ima-prod
+                  name: ima-rds-prod
                   {{ end }}
             - name: DB_PASS
               valueFrom:
                 secretKeyRef:
                   key: password
-                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) }}
+                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV)}}
                   name: ima-notprod-rds
                   {{ else }}
-                  name: ima-prod
+                  name: ima-rds-prod
                   {{ end }}
           resources:
             requests:

--- a/kube/hof-rds-api/ingress.yml
+++ b/kube/hof-rds-api/ingress.yml
@@ -13,7 +13,7 @@ spec:
   tls:
     - hosts:
       {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
-        # - TO BE UPDATED ONCE URL IS PROVIDED
+        - data-service.illegal-migration-act.homeoffice.gov.uk
       {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
         - ima-data-service.stg.sas.homeoffice.gov.uk
       {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
@@ -29,7 +29,7 @@ spec:
       {{ end }}
   rules:
     {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
-    # - host: TO BE UPDATED ONCE URL IS PROVIDED
+    - data-service.illegal-migration-act.homeoffice.gov.uk
     {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
     - host: ima-data-service.stg.sas.homeoffice.gov.uk
     {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}


### PR DESCRIPTION
## What?

Deployments in Stage env are using Production secrets for rds and s3. Now We have added a condition for deployments in stage to use the secrets(s3 bucket, rds secret) of Branch/UAT env. Updated Secret name from ima-prod to ima-rds-prod to give a meaningful context.
Cron jobs enabled in Stage env.
Production url has been added  
Removed Anchore-inline scanner which has reached End Of Life ( as mentioned in anchore website). We have also removed it from all the services.
 
## Why?
We are setting up Stage and Production environment.  Deployments in stage and prod requires secrets of s3 bucket and rds instances.
dataservice ingress url in production depends on the production url. 

## How?
Added conditions wherever necessary in the deployment files to refer the secrets which are supposed to be used. 

## Testing?
Deployments to relevant namespaces can help us find for any missing configs. Follow up to the error messages we can update the repo with the missing configs ( secrets, Ingress etc) 

## Screenshots (optional)
## Anything Else? (optional)
