### PR TITLE
IMB-156: Fix bug of exceeding SIH country limit

### DIFF
--- a/apps/ima/behaviours/harm-claim-summary.js
+++ b/apps/ima/behaviours/harm-claim-summary.js
@@ -15,9 +15,9 @@ module.exports = superclass => class extends superclass {
       const countryName = req.sessionModel.get('sih-countries').aggregatedValues;
       _.forEach(i.fields, field => {
         if (field.field === 'is-risk-in-country') {
-          if (field.value.includes('yes')) {
+          if (field.value !== undefined && field.value.includes('yes')) {
             field.parsed = 'Yes';
-          } else if (field.value.includes('no')) {
+          } else if (field.value !== undefined && field.value.includes('no')) {
             field.parsed = 'No';
           }
         }

--- a/apps/ima/behaviours/limit-countries.js
+++ b/apps/ima/behaviours/limit-countries.js
@@ -1,12 +1,14 @@
 module.exports = superclass => class extends superclass {
   locals(req, res) {
     const locals = super.locals(req, res);
-    const harmClaims = req.sessionModel.get('sih-countries').aggregatedValues;
-    const harmClaimLimit = harmClaims.length >= 5;
+    if(req.sessionModel.get('sih-countries') !== undefined) {
+      const harmClaims = req.sessionModel.get('sih-countries').aggregatedValues;
+      const harmClaimLimit = harmClaims.length >= 5;
 
-    if (harmClaims && harmClaimLimit) {
-      locals.noMoreHarmClaims = true;
-      return locals;
+      if (harmClaims && harmClaimLimit) {
+        locals.noMoreHarmClaims = true;
+        return locals;
+      }
     }
 
     return locals;

--- a/apps/ima/behaviours/modify-change-link.js
+++ b/apps/ima/behaviours/modify-change-link.js
@@ -6,7 +6,7 @@ module.exports = superclass => class extends superclass {
   locals(req, res) {
     const locals = super.locals(req, res);
     // set change link for for family-members field
-    if (locals.route === 'final-summary') {
+    if (locals.route === 'final-summary' || locals.route === 'summary') {
       _.forEach(locals.rows, fields => {
         locals.rows = locals.rows.map(row => {
           if (row.section === 'Human rights') {

--- a/apps/ima/behaviours/reset-harm-claim-summary.js
+++ b/apps/ima/behaviours/reset-harm-claim-summary.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = superclass => class extends superclass {
+  saveValues(req, res, next) {
+    if(req.sessionModel.get('sih-countries') !== undefined) {
+      if(req.sessionModel.get('is-serious-and-irreversible') === 'no' &&
+      req.sessionModel.get('sih-countries').aggregatedValues.length > 0) {
+        req.sessionModel.unset('sih-countries');
+      }
+    }
+    return super.saveValues(req, res, next);
+  }
+};

--- a/apps/ima/sections/summary-data-sections.js
+++ b/apps/ima/sections/summary-data-sections.js
@@ -191,7 +191,7 @@ module.exports = {
         step: '/harm-claim-summary',
         field: 'sih-countries',
         parse: (list, req) => {
-          if (!req.sessionModel.get('steps').includes('/harm-claim-summary')) {
+          if (req.sessionModel.get('sih-countries') === undefined || req.sessionModel.get('sih-countries').length < 1) {
             return null;
           }
           return req.sessionModel.get('is-serious-and-irreversible') === 'yes' ?

--- a/apps/ima/views/confirm.html
+++ b/apps/ima/views/confirm.html
@@ -1,4 +1,3 @@
-<title>{{#t}}pages.confirm.header{{/t}} – GOV.UK</title>
 {{<partials-page}}
   {{$pageTitle}}{{#t}}pages.confirm.header{{/t}} – GOV.UK{{/pageTitle}}
   {{$page-content}}

--- a/apps/ima/views/harm-claim-countries.html
+++ b/apps/ima/views/harm-claim-countries.html
@@ -2,7 +2,11 @@
 {{$encoding}}enctype="multipart/form-data"{{/encoding}}
   {{$page-content}}
 
-    <p>{{#t}}pages.harm-claim-countries.paragraph1{{/t}}</p>
+  {{#noMoreHarmClaims}}
+    <p class="govuk-body"><strong>You will not be able to add another country as 5 have already been added. To add another, please go to the summary and delete one first.</strong></p>
+  {{/noMoreHarmClaims}}
+
+  <p>{{#t}}pages.harm-claim-countries.paragraph1{{/t}}</p>
   <br>
   
   <div id="harm-claim-country-repeater" class="repeater">

--- a/apps/ima/views/harm-claim-details.html
+++ b/apps/ima/views/harm-claim-details.html
@@ -1,6 +1,9 @@
 {{<partials-page}}
   {{$page-content}}
  
+  {{#noMoreHarmClaims}}
+    <p class="govuk-body"><strong>You will not be able to add another country as 5 have already been added. To add another, please go to the summary and delete one first.</strong></p>
+  {{/noMoreHarmClaims}}
   {{#markdown}}harm-claim-details{{/markdown}}
     <br>
     {{#renderField}}reason-in-sih{{/renderField}}

--- a/apps/ima/views/risk-of-harm.html
+++ b/apps/ima/views/risk-of-harm.html
@@ -1,5 +1,8 @@
 {{<partials-page}}
   {{$page-content}}
+    {{#noMoreHarmClaims}}
+      <p class="govuk-body"><strong>You will not be able to add another country as 5 have already been added. To add another, please go to the summary and delete one first.</strong></p>
+    {{/noMoreHarmClaims}}
     {{#markdown}}risk-of-harm{{/markdown}}
     <br>
     <br>


### PR DESCRIPTION
## What?

**Fix issues caused by pressing the browser back button on the IMA SIH section:**

- Fix bug where user is able to add more than five countries  - [IMB-156](https://collaboration.homeoffice.gov.uk/jira/browse/IMB-156)
- Fix bug where user is able to add an SIH country with a blank title after deleting an SIH country (observed while testing the fix for IMB-156)

**Fix routing logic on the SIH section**

## Why?
- To prevent the ability to add more than five countries to the SIH section
- To prevent the adding of a record in the SIH section without a title
- To correct the routing issues on the SIH section

## How?
- add logic in `/behaviours/aggregator-save-update.js` to prevent the adding of a country if there are already five in the list, or if the country being added has a blank title
- add an 'undefined' check in `/behaviours/harm-claim-summary.js` to fix the issue when a country has a blank title and the form is not able to get to the SIH summary page
- add fork logic to `index.js` to redirect to the harm-claim-countries page if 'yes' is selected on the harm-claim page, and the SIH country list is empty
- add info text to SIH section screens to warn the user of being unable to add further countries once the limit has been exceeded (if they use the browser back button to access those screens)
- add conditional logic in `/behaviours/save-form-session.js` to override the routing functionality in the SIH screens
- add `reset-harm-claim-summary.js` behaviour to clear the sih-countries if the user selects 'no' on the harm-claim page

## Testing?
Tested locally and in branch

## Screenshots (optional)

## Anything Else? (optional)
