### PR TITLE
IMB-111: Update Ingress for data-service

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -12,6 +12,11 @@ ignore:
         reason: HOF framework needs updating to remove request.js of which this is a dependency
         expires: 2024-07-24T00:00:00.000Z
         created: 2024-04-24T12:12:47.350Z
+  SNYK-JS-BRACES-6838727:
+    - '*':
+        reason: No upgrade or patch available
+        expires: 2024-08-17T00:00:00.000Z
+        created: 2024-05-17T12:12:47.350Z
   SNYK-JS-XML2JS-5414874:
     - '*':
         reason: No direct upgrade or patch available
@@ -72,4 +77,5 @@ ignore:
        reason: no direct upgrade or patch available
        expires: 2024-07-24T00:00:00.000Z
        created: 2024-04-24T11:31:47.350Z
+  
 patch: {}

--- a/.snyk
+++ b/.snyk
@@ -77,13 +77,4 @@ ignore:
        reason: no direct upgrade or patch available
        expires: 2024-07-24T00:00:00.000Z
        created: 2024-04-24T11:31:47.350Z
-<<<<<<< IMB-111
-  
-=======
-  SNYK-JS-BRACES-6838727:
-    - '*':
-       reason: no direct upgrade or patch available
-       expires: 2024-08-17T00:00:00.000Z
-       created: 2024-05-17T19:05:47.350Z
->>>>>>> master
 patch: {}

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -5,7 +5,7 @@ export INGRESS_INTERNAL_ANNOTATIONS=$HOF_CONFIG/ingress-internal-annotations.yam
 export INGRESS_EXTERNAL_ANNOTATIONS=$HOF_CONFIG/ingress-external-annotations.yaml
 export CONFIGMAP_VALUES=$HOF_CONFIG/configmap-values.yaml
 export NGINX_SETTINGS=$HOF_CONFIG/nginx-settings.yaml
-export DATA_SERVICE_EXTERNAL_ANNOTATIONS=$HOF_CONFIG/data-service-external-annotations.yaml
+export DATA_SERVICE_INTERNAL_ANNOTATIONS=$HOF_CONFIG/data-service-internal-annotations.yaml
 export FILEVAULT_NGINX_SETTINGS=$HOF_CONFIG/filevault-nginx-settings.yaml
 export FILEVAULT_INGRESS_EXTERNAL_ANNOTATIONS=$HOF_CONFIG/filevault-ingress-external-annotations.yaml
 

--- a/kube/hof-rds-api/ingress.yml
+++ b/kube/hof-rds-api/ingress.yml
@@ -7,7 +7,7 @@ metadata:
   {{ else }}
   name: data-service
   {{ end }}
-{{ file .DATA_SERVICE_INTERNAL_ANNOTATIONS | indent 2 }}
+{{ file .DATA_SERVICE_EXTERNAL_ANNOTATIONS | indent 2 }}
 spec:
   ingressClassName: nginx-internal
   tls:

--- a/kube/hof-rds-api/ingress.yml
+++ b/kube/hof-rds-api/ingress.yml
@@ -7,13 +7,13 @@ metadata:
   {{ else }}
   name: data-service
   {{ end }}
-{{ file .DATA_SERVICE_EXTERNAL_ANNOTATIONS | indent 2 }}
+{{ file .DATA_SERVICE_INTERNAL_ANNOTATIONS | indent 2 }}
 spec:
-  ingressClassName: nginx-external
+  ingressClassName: nginx-internal
   tls:
     - hosts:
       {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
-        - data-service.illegal-migration-act.homeoffice.gov.uk
+        - ima-data-service.sas.homeoffice.gov.uk
       {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
         - ima-data-service.stg.sas.homeoffice.gov.uk
       {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
@@ -23,13 +23,13 @@ spec:
         - data-service-{{ .DRONE_SOURCE_BRANCH }}.branch.sas-notprod.homeoffice.gov.uk
       {{ end }}
       {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-      secretName: branch-tls-external
+      secretName: branch-tls-internal
       {{ else }}
       secretName: data-service-cert-cmio
       {{ end }}
   rules:
     {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
-    - data-service.illegal-migration-act.homeoffice.gov.uk
+    - host: ima-data-service.sas.homeoffice.gov.uk
     {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
     - host: ima-data-service.stg.sas.homeoffice.gov.uk
     {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}

--- a/kube/hof-rds-api/ingress.yml
+++ b/kube/hof-rds-api/ingress.yml
@@ -7,7 +7,7 @@ metadata:
   {{ else }}
   name: data-service
   {{ end }}
-{{ file .DATA_SERVICE_EXTERNAL_ANNOTATIONS | indent 2 }}
+{{ file .DATA_SERVICE_INTERNAL_ANNOTATIONS | indent 2 }}
 spec:
   ingressClassName: nginx-internal
   tls:


### PR DESCRIPTION
## What?

We are replacing External Ingress with Internal Ingress for data service. data service is backend service and cannot be externally accessed with external ingress. 

## Why?
Team have decided to use internal ingress. All the Policy admissions added to the namespaces to allow internal ingress which is now pointing to the internal ingress of ACP.  Route53 is configured for the internal ingress


## How?

Added Internal Ingress Annotations to the Internal Ingress used by Data Service 
This file is added in Hof-service-config git repo
IMA (with Data service as internal ingress) is Tested in Branch Env by QAT team. They have approved us to progress to UAT. After tested Okay without issues we promote these changes to Stage and then to Prod (Progressive Approach)
We have updated in deploy.sh to use Internal Ingress Annotations.

## Testing?
Tested by The QAT team in Branch Env. 

## Screenshots (optional)


## Anything Else? (optional)
After tests External Ingress annotations of Data service will be removed from hof-services-config