### PR TITLE
IMB-172 csv file bug fix

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -72,4 +72,9 @@ ignore:
        reason: no direct upgrade or patch available
        expires: 2024-07-24T00:00:00.000Z
        created: 2024-04-24T11:31:47.350Z
+  SNYK-JS-BRACES-6838727:
+    - '*':
+       reason: no direct upgrade or patch available
+       expires: 2024-08-17T00:00:00.000Z
+       created: 2024-05-17T19:05:47.350Z
 patch: {}

--- a/apps/ima/index.js
+++ b/apps/ima/index.js
@@ -805,7 +805,7 @@ module.exports = {
       ]
     },
     '/declaration': {
-      behaviours: [Summary, Submit],
+      behaviours: [SaveFormSession, Summary, Submit],
       sections: require('./sections/summary-data-sections'),
       fields: [
         'person-declaration'
@@ -814,7 +814,7 @@ module.exports = {
       next: '/form-submitted'
     },
     '/immigration-adviser-declaration': {
-      behaviours: [Summary, Submit],
+      behaviours: [SaveFormSession, Summary, Submit],
       sections: require('./sections/summary-data-sections'),
       fields: ['use-interpreter',
         'immigration-adviser-declaration', 'language-used'
@@ -823,7 +823,7 @@ module.exports = {
       next: '/form-submitted'
     },
     '/helper-declaration': {
-      behaviours: [Summary, Submit],
+      behaviours: [SaveFormSession, Summary, Submit],
       sections: require('./sections/summary-data-sections'),
       fields: ['use-interpreter',
         'helper-declaration', 'language-used'


### PR DESCRIPTION
## What?
IMA report - Declaration data not tracked - [IMB-172](https://collaboration.homeoffice.gov.uk/jira/browse/IMB-172)

## Why?
- The csv file did not show all the saved values of declaration data
- So that the user can view the saved session values of declaration data correctly in the csv file in reports

## How?
- add SaveFormSession behaviour to '/declaration',  '/immigration-adviser-declaration' and '/helper-declaration' in index.js
- SNYK file changes for vulnerability SNYK-JS-BRACES-6838727

## Testing?
Tested locally

## Screenshots (optional)
## Anything Else? (optional)
