### PR TITLE
IMB-159: Temporary permission screen wording change

### DIFF
--- a/apps/ima/views/temporary-permission.html
+++ b/apps/ima/views/temporary-permission.html
@@ -1,6 +1,5 @@
 {{<partials-page}}
   {{$page-content}}
-    <p class="govuk-body">Do not use this question to make an asylum claim. Any asylum claim will be inadmissible.</p>
     <strong>{{#t}}fields.temporary-permission-reasons-ban-only.label{{/t}}</strong>
     <p class="govuk-body">Any reasons given may not prevent you being removed from the UK.</p>
     {{#renderField}}temporary-permission-reasons-ban-only{{/renderField}}


### PR DESCRIPTION
## What?
Update wording on the temporary-permission screen - [IMB-159](https://collaboration.homeoffice.gov.uk/jira/browse/IMB-159)

## Why?
To match the latest Figma designs

## How?
- remove first paragraph in `temporary-permission.html`

## Testing?
Tested locally and in branch

## Screenshots (optional)
## Anything Else? (optional)
