### PR TITLE
IMB-111: Add Secret ref for Stage Environment

### DIFF
--- a/kube/app/deployment.yml
+++ b/kube/app/deployment.yml
@@ -124,7 +124,7 @@ spec:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
-                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV)}}
+                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV)}}
                   name: ima-s3-bucket-secret
                   {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
                   name: ima-stg-s3

--- a/kube/app/deployment.yml
+++ b/kube/app/deployment.yml
@@ -126,6 +126,8 @@ spec:
                 secretKeyRef:
                   {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV)}}
                   name: ima-s3-bucket-secret
+                  {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
+                  name: ima-stg-s3
                   {{ else }}
                   name: ima-s3-prod
                   {{ end }}
@@ -133,8 +135,10 @@ spec:
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV)}}
+                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV)}}
                   name: ima-s3-bucket-secret
+                  {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
+                  name: ima-stg-s3
                   {{ else }}
                   name: ima-s3-prod
                   {{ end }}
@@ -142,8 +146,10 @@ spec:
             - name: AWS_KMS_KEY_ID
               valueFrom:
                 secretKeyRef:
-                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV)}}
+                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV)}}
                   name: ima-s3-bucket-secret
+                  {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
+                  name: ima-stg-s3
                   {{ else }}
                   name: ima-s3-prod
                   {{ end }}
@@ -151,8 +157,10 @@ spec:
             - name: AWS_BUCKET
               valueFrom:
                 secretKeyRef:
-                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV)}}
+                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV)}}
                   name: ima-s3-bucket-secret
+                  {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
+                  name: ima-stg-s3
                   {{ else }}
                   name: ima-s3-prod
                   {{ end }}

--- a/kube/cron/hof_db_table_replacer.yaml
+++ b/kube/cron/hof_db_table_replacer.yaml
@@ -77,8 +77,10 @@ spec:
                 valueFrom:
                   secretKeyRef:
                     key: endpoint
-                    {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV)}}
+                    {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV)}}
                     name: ima-notprod-rds
+                    {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
+                    name: ima-stg-rds
                     {{ else }}
                     name: ima-rds-prod
                     {{ end }}
@@ -86,8 +88,10 @@ spec:
                 valueFrom:
                   secretKeyRef:
                     key: db_name
-                    {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV)}}
+                    {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV)}}
                     name: ima-notprod-rds
+                    {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
+                    name: ima-stg-rds
                     {{ else }}
                     name: ima-rds-prod
                     {{ end }}
@@ -95,8 +99,10 @@ spec:
                 valueFrom:
                   secretKeyRef:
                     key: username
-                    {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV)}}
+                    {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV)}}
                     name: ima-notprod-rds
+                    {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
+                    name: ima-stg-rds
                     {{ else }}
                     name: ima-rds-prod
                     {{ end }}
@@ -104,8 +110,10 @@ spec:
                 valueFrom:
                   secretKeyRef:
                     key: password
-                    {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV)}}
+                    {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV)}}
                     name: ima-notprod-rds
+                    {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
+                    name: ima-stg-rds
                     {{ else }}
                     name: ima-rds-prod
                     {{ end }}

--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -75,8 +75,10 @@ spec:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
-                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) }}
+                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV)}}
                   name: ima-s3-bucket-secret
+                  {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
+                  name: ima-stg-s3
                   {{ else }}
                   name: ima-s3-prod
                   {{ end }}
@@ -84,8 +86,10 @@ spec:
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV)}}
+                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV)}}
                   name: ima-s3-bucket-secret
+                  {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
+                  name: ima-stg-s3
                   {{ else }}
                   name: ima-s3-prod
                   {{ end }}
@@ -93,8 +97,10 @@ spec:
             - name: AWS_KMS_KEY_ID
               valueFrom:
                 secretKeyRef:
-                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV)}}
+                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV)}}
                   name: ima-s3-bucket-secret
+                  {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
+                  name: ima-stg-s3
                   {{ else }}
                   name: ima-s3-prod
                   {{ end }}
@@ -102,8 +108,10 @@ spec:
             - name: AWS_BUCKET
               valueFrom:
                 secretKeyRef:
-                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV)}}
+                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV)}}
                   name: ima-s3-bucket-secret
+                  {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
+                  name: ima-stg-s3
                   {{ else }}
                   name: ima-s3-prod
                   {{ end }}

--- a/kube/hof-rds-api/deployment.yml
+++ b/kube/hof-rds-api/deployment.yml
@@ -56,8 +56,10 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: endpoint
-                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV)}}
+                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV)}}
                   name: ima-notprod-rds
+                  {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
+                  name: ima-stg-rds
                   {{ else }}
                   name: ima-rds-prod
                   {{ end }}
@@ -65,8 +67,10 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: db_name
-                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV)}}
+                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV)}}
                   name: ima-notprod-rds
+                  {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
+                  name: ima-stg-rds
                   {{ else }}
                   name: ima-rds-prod
                   {{ end }}
@@ -74,8 +78,10 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: username
-                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV)}}
+                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV)}}
                   name: ima-notprod-rds
+                  {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
+                  name: ima-stg-rds
                   {{ else }}
                   name: ima-rds-prod
                   {{ end }}
@@ -83,8 +89,10 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: password
-                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV)}}
+                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV)}}
                   name: ima-notprod-rds
+                  {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
+                  name: ima-stg-rds
                   {{ else }}
                   name: ima-rds-prod
                   {{ end }}


### PR DESCRIPTION
## What?

ACP team have created S3 buckets and RDS instance for Stage. Secrets have been added to the namespaces. We need our code to reference the secrets added in namespace. I have added the conditions for stage to use the secrets of S3 and RDS instances

## Why?
Stage deployments are unable to connect the RDS instances and s3 buckets used for branch and UAT env. ACP team have suggested us to create one for Staging. These Stage S3 buckets and RDS instance in stage are identical to prod. Performance testing will be done on staging so should be identical (AWS resources. pods etc) to prod. Using lower environment AWS resources is ruled out

## How?
deployment.yaml for all the deployments have references to these secrets. They have been updated including the cron jobs. 

## Testing?
The only way to test these is by deploying into the relevant Environments.

## Screenshots (optional)
## Anything Else? (optional)
