### PR TITLE
IMB-161: Add email to the form submitted page

### DIFF
--- a/apps/ima/behaviours/set-static-emails.js
+++ b/apps/ima/behaviours/set-static-emails.js
@@ -1,0 +1,9 @@
+const config = require('../../../config');
+
+module.exports = superclass => class extends superclass {
+  locals(req, res) {
+    const locals = super.locals(req, res);
+    locals.queriesEmail = config.queriesEmail;
+    return locals;
+  }
+};

--- a/apps/ima/views/content/form-submitted.md
+++ b/apps/ima/views/content/form-submitted.md
@@ -3,14 +3,14 @@
   <li>{{#t}}pages.form-submitted.list2{{/t}}</li>
 </ul>
 
-If your address changes, email your new address to IMAqueries@homeoffice.gov.uk
+If your address changes, email your new address to {{queriesEmail}}
 
 ### If you need to send more evidence
 <div class="evidence-list">
 If you have been given a claim period and need to send evidence after the end of the period, you need to:
 
 1. apply for an extension before the end end of your claim period
-2. send your evidence to IMAqueries@homeoffice.gov.uk as soon as possible
+2. send your evidence to {{queriesEmail}} as soon as possible
 </div>
 <br>
 Do not wait for confirmation that you have been granted an extension to send your evidence.

--- a/config.js
+++ b/config.js
@@ -7,6 +7,7 @@ module.exports = {
   PRETTY_DATE_FORMAT: 'Do MMMM YYYY',
   dateTimeFormat: 'D MMM YYYY HH:mm:ss',
   env: env,
+  queriesEmail: process.env.QUERIES_EMAIL,
   dataDirectory: './data',
   aws: {
     bucket: process.env.AWS_BUCKET,

--- a/hof.settings.json
+++ b/hof.settings.json
@@ -2,7 +2,8 @@
   "appName": "Illegal Migration Act",
   "theme": "govUK",
   "behaviours": [
-    "hof/components/clear-session"
+    "hof/components/clear-session",
+    "./apps/ima/behaviours/set-static-emails"
   ],
   "build": {
     "watch": {

--- a/test/_unit/server.spec.js
+++ b/test/_unit/server.spec.js
@@ -32,6 +32,7 @@ describe('Server.js app file', () => {
     appsCeprStub = sinon.stub();
     appsImaStub = sinon.stub();
     behavioursClearSessionStub = sinon.stub();
+    behavioursSetStaticEmailsStub = sinon.stub();
     req.get.withArgs('host').returns('localhost');
 
     useStub.onCall(0).yields(req, res, next);
@@ -44,6 +45,7 @@ describe('Server.js app file', () => {
       './apps/cepr': appsCeprStub,
       './apps/verify': appsVerifyStub,
       'hof/components/clear-session': behavioursClearSessionStub,
+      './apps/ima/behaviours/set-static-emails': behavioursSetStaticEmailsStub,
       './config': { env: 'test' }
     });
   });
@@ -54,7 +56,8 @@ describe('Server.js app file', () => {
         appName: 'Illegal Migration Act',
         theme: 'govUK',
         behaviours: [
-          behavioursClearSessionStub
+          behavioursClearSessionStub,
+          behavioursSetStaticEmailsStub
         ],
         build: {
           watch: {


### PR DESCRIPTION
## What?
Add the queries email to the IMA form-submitted page - [IMB-161](https://collaboration.homeoffice.gov.uk/jira/browse/IMB-161)

## Why?
So the user is provided information on the email address to send further evidence to

## How?
- add 'queriesEmail' property to `config.js` to pull the email address value from the secrets file
- add `/behaviours/enquiries-email-local.js` to pull the email address from `config.js`
- include the enquiries-email-local.js behaviour in `hof.settings.json`
- add the 'queriesEmail' variable into `/views/content/form-submitted.md` to populate the email address on the form-submitted page
- add the new enquiries-email-local.js behaviour to `/test/_unit/server.spec.js` as part of the 'Setup HOF Configuration' test case

## Testing?
Tested locally and in branch

## Screenshots (optional)
<img width="831" alt="image" src="https://github.com/UKHomeOffice/ima/assets/142597294/68d3dff7-cb56-4dfb-ae57-96b9541c5d24">


## Anything Else? (optional)
