### PR TITLE
IMB-189: De-index IMA webform

### DIFF
--- a/apps/ima/views/partials/head.html
+++ b/apps/ima/views/partials/head.html
@@ -1,0 +1,26 @@
+{{#gtmTagId}}
+{{#cookiesAccepted}}
+<!-- Google Tag Manager Data Layer  -->
+<script {{#nonce}}nonce="{{nonce}}"{{/nonce}}>
+  var dataLayer = window.dataLayer || [];
+  dataLayer.push(
+    {{{gtmConfig}}}
+  );
+</script>
+<!-- End Google Tag Manager Data Layer  -->
+
+<!-- Google Tag Manager -->
+<script {{#nonce}}nonce="{{nonce}}"{{/nonce}}>
+  (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','{{gtmTagId}}');
+</script>
+<!-- End Google Tag Manager -->
+{{/cookiesAccepted}}
+{{/gtmTagId}}
+
+<meta name="robots" content="noindex">
+<meta name="format-detection" content="telephone=no">
+<link rel="stylesheet" href="{{assetPath}}/css/app.css">

--- a/apps/verify/views/partials/head.html
+++ b/apps/verify/views/partials/head.html
@@ -1,0 +1,26 @@
+{{#gtmTagId}}
+{{#cookiesAccepted}}
+<!-- Google Tag Manager Data Layer  -->
+<script {{#nonce}}nonce="{{nonce}}"{{/nonce}}>
+  var dataLayer = window.dataLayer || [];
+  dataLayer.push(
+    {{{gtmConfig}}}
+  );
+</script>
+<!-- End Google Tag Manager Data Layer  -->
+
+<!-- Google Tag Manager -->
+<script {{#nonce}}nonce="{{nonce}}"{{/nonce}}>
+  (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','{{gtmTagId}}');
+</script>
+<!-- End Google Tag Manager -->
+{{/cookiesAccepted}}
+{{/gtmTagId}}
+
+<meta name="robots" content="noindex">
+<meta name="format-detection" content="telephone=no">
+<link rel="stylesheet" href="{{assetPath}}/css/app.css">


### PR DESCRIPTION
## What?
Add robots meta tag to de-index the entire IMA form - [IMB-189](https://collaboration.homeoffice.gov.uk/jira/browse/IMB-189). Similarly done for ETA ([ETA-123](https://collaboration.homeoffice.gov.uk/jira/browse/ETA-123))

## Why?
So that the form is not returned in browser searches

## How?
- add the `/ima/views/partials/head.html` file with the 'robots noindex' meta tag to ensure it is added to the head section of all the form's pages
- add the '/verify/views/partials/head.html' file the same as the one above

## Testing?
Tested locally and in branch

## Screenshots (optional)
**Verify flow:**
<img width="1438" alt="image" src="https://github.com/UKHomeOffice/ima/assets/142597294/ac22b467-6d40-48e9-a77d-9dad00ee844f">

**Main flow:**
<img width="1438" alt="image" src="https://github.com/UKHomeOffice/ima/assets/142597294/f8d42f0a-8f96-4190-ab62-8793b94065a3">


## Anything Else? (optional)
