### PR TITLE
IMB-191 Add email address to Medical Records content

### DIFF
--- a/apps/ima/translations/src/en/pages.json
+++ b/apps/ima/translations/src/en/pages.json
@@ -41,7 +41,7 @@
   },
   "medical-records": {
     "header": "Your medical records",
-    "response-label1": "You can change your mind at any time by emailing [EMAIL ADDRESS] to tell the Home Office they no longer have permission to access your medical records."
+    "response-label1": "You can change your mind at any time by emailing {{queriesEmail}} to tell the Home Office they no longer have permission to access your medical records."
   },
   "exception": {
     "header": "Does an exception to the duty to remove apply to you?"


### PR DESCRIPTION
## What?
Add email address to Medical Records content - [IMB-191](https://collaboration.homeoffice.gov.uk/jira/browse/IMB-191)
## Why?
Email address is not showing under the Medical Records content
## How?
Email address {{queriesEmail}} has been added to the medical-records in pages.json so that queriesEmail will be populated dynamically from env variables
## Testing?
Testing done locally

