### PR TITLE
IMB-207

### DIFF
--- a/apps/ima/sections/summary-data-sections.js
+++ b/apps/ima/sections/summary-data-sections.js
@@ -232,7 +232,7 @@ module.exports = {
             return null;
           }
           return req.sessionModel.get('arrived-without-clearance') === 'no' ?
-            list + '\n"' + req.sessionModel.get('arrived-without-clearance-detail') : list;
+            list + '\n' + req.sessionModel.get('arrived-without-clearance-detail') : list;
         }
       },
       {


### PR DESCRIPTION
## What?
[IMB-207 Extra double quote symbol ](https://collaboration.homeoffice.gov.uk/jira/browse/IMB-207)
 
## Why?
Extra double quote symbol visible in summary section
 
## How?
- In sections under summary-data-sections.js  in removal-conditions extra double quote was removed in '\n"'
 
## Testing?
Tested locally